### PR TITLE
⚙️  cnfig: #63 Dock内メニューの名称変更、削除

### DIFF
--- a/app/views/shared/_dock.html.erb
+++ b/app/views/shared/_dock.html.erb
@@ -1,17 +1,12 @@
 <div class="dock text-2xl">
   <button class="dock-active">
     <i class="ph ph-house"></i>
-    <span class="dock-label">Home</span>
+    <span class="dock-label">Dashboard</span>
   </button>
 
   <button>
     <i class="ph ph-clock-counter-clockwise"></i>
-    <span class="dock-label">History</span>
-  </button>
-
-  <button>
-    <i class="ph ph-chart-line-up"></i>
-    <span class="dock-label">Status</span>
+    <span class="dock-label">Records</span>
   </button>
 
   <button>


### PR DESCRIPTION
命名が分かりにくかったため修正、HistoryとRecordsは一つにまとめるためHistoryを削除