### PR TITLE
🐛 fix: wake_timeのバリデーションを削除

### DIFF
--- a/app/models/sleep_record.rb
+++ b/app/models/sleep_record.rb
@@ -2,7 +2,6 @@ class SleepRecord < ApplicationRecord
   belongs_to :user
 
   validates :bed_time, presence: true
-  validates :wake_time, presence: true
   validate :wake_time_after_bed_time
 
   validates :note, length: { maximum: 100 }, allow_blank: true

--- a/db/migrate/20250910151124_change_wake_time_nullable_in_sleep_records.rb
+++ b/db/migrate/20250910151124_change_wake_time_nullable_in_sleep_records.rb
@@ -1,0 +1,5 @@
+class ChangeWakeTimeNullableInSleepRecords < ActiveRecord::Migration[7.2]
+  def change
+    change_column :sleep_records, :wake_time, :datetime, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_10_022512) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_10_151124) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "sleep_records", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.datetime "bed_time", null: false
-    t.datetime "wake_time", null: false
+    t.datetime "wake_time"
     t.text "note"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
sleep_timeボタンを押しても記録がされず原因を探った結果最初に記録できないwake_timeがnillを許可しない設定になっていたのが原因だったため