### PR TITLE
Feature/sleep records wake time base

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -2,17 +2,97 @@ class DashboardController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    sleep_records = current_user.sleep_records.order(:bed_time)
-    @unwoken_record = sleep_records.unwoken.first
+    sleep_records = current_user.sleep_records.includes(:user).order(:wake_time)
+    finished_records = sleep_records.finished
 
+    @unwoken_record = sleep_records.unbedded.first
     @series = SleepRecord.build_series(sleep_records, days: 7)
     @weekly_records = SleepRecord.build_weekly_cumulative(sleep_records, days: 7)
+    @today_sleep = find_today_sleep_record(finished_records)
 
-    finished_records = sleep_records.select(&:wake_time)
-    @today_sleep = finished_records.find do |r|
-      r.bed_time.to_date == Date.current && r.wake_time.to_date == Date.current
+    @average_sleep_hours = calculate_average_sleep_hours(finished_records)
+    @average_wake_hours = calculate_average_wake_hours(finished_records)
+
+    @weekly_average_sleep_hours = calculate_weekly_average_sleep_hours
+    @weekly_average_wake_hours = calculate_weekly_average_wake_hours
+
+    @average_wake_time = calculate_average_wake_time(sleep_records.with_wake_time)
+    @average_bed_time = calculate_average_bed_time(finished_records)
+
+    @weekly_cumulative_wake_hours = calculate_weekly_cumulative_wake_hours
+    @weekly_cumulative_sleep_hours = calculate_weekly_cumulative_sleep_hours
+  end
+
+  private
+
+  def find_today_sleep_record(records)
+    today = Date.current
+    records.find_by("DATE(wake_time) = ?", today)
+  end
+
+  def calculate_average_sleep_hours(records)
+    return 0.0 if records.empty?
+    total_sleep_hours = SleepRecord.total_sleep_hours(records)
+    (total_sleep_hours / records.size).round(2)
+  end
+
+  def calculate_average_wake_hours(records)
+    return 0.0 if records.empty?
+    total_wake_hours = records.sum { |record| SleepRecord.calculate_daily_wake(record, record) || 0 }
+    (total_wake_hours / records.size).round(2)
+  end
+
+  def calculate_weekly_average_sleep_hours
+    return nil if @weekly_records.empty?
+    sleep_hours = @weekly_records.map { |r| r[:daily_sleep_hours] }.compact
+    return nil if sleep_hours.empty?
+    (sleep_hours.sum / sleep_hours.size).round(2)
+  end
+
+  def calculate_weekly_average_wake_hours
+    return nil if @weekly_records.empty?
+    wake_hours = @weekly_records.map { |r| r[:daily_wake_hours] }.compact
+    return nil if wake_hours.empty?
+    (wake_hours.sum / wake_hours.size).round(2)
+  end
+
+  def calculate_average_wake_time(records)
+    return nil if records.empty?
+    total_seconds = records.sum do |record|
+      time = record.wake_time.in_time_zone
+      time.hour * 3600 + time.min * 60 + time.sec
     end
-    @total_sleep_hours = SleepRecord.total_sleep_hours(finished_records)
-    @average_sleep_hours = finished_records.any? ? (@total_sleep_hours / finished_records.size).round(2) : 0
+    average_seconds = total_seconds / records.size
+    hours = (average_seconds / 3600).to_i
+    minutes = ((average_seconds % 3600) / 60).to_i
+    hours -= 24 if hours >= 24
+    sprintf("%02d:%02d", hours, minutes)
+  end
+
+  def calculate_average_bed_time(records)
+    return nil if records.empty?
+    total_seconds = records.sum do |record|
+      time = record.bed_time.in_time_zone
+      seconds = time.hour * 3600 + time.min * 60 + time.sec
+      seconds += 24 * 3600 if time.hour < 6  # 深夜0-6時を翌日扱い
+      seconds
+    end
+    average_seconds = total_seconds / records.size
+    average_seconds -= 24 * 3600 if average_seconds >= 24 * 3600
+    hours = (average_seconds / 3600).to_i
+    minutes = ((average_seconds % 3600) / 60).to_i
+    sprintf("%02d:%02d", hours, minutes)
+  end
+
+  def calculate_weekly_cumulative_wake_hours
+    return nil if @weekly_records.empty?
+    latest_record = @weekly_records.last
+    latest_record[:cumulative_wake_hours]&.to_f || 0.0
+  end
+
+  def calculate_weekly_cumulative_sleep_hours
+    return nil if @weekly_records.empty?
+    latest_record = @weekly_records.last
+    latest_record[:cumulative_sleep_hours]&.to_f || 0.0
   end
 end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -2,97 +2,24 @@ class DashboardController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    sleep_records = current_user.sleep_records.includes(:user).order(:wake_time)
-    finished_records = sleep_records.finished
+    week_start = Date.current.beginning_of_week(:sunday).beginning_of_day
+    week_end   = Date.current.end_of_week(:sunday).end_of_day
 
-    @unwoken_record = sleep_records.unbedded.first
-    @series = SleepRecord.build_series(sleep_records, days: 7)
-    @weekly_records = SleepRecord.build_weekly_cumulative(sleep_records, days: 7)
-    @today_sleep = find_today_sleep_record(finished_records)
+    @week_records = current_user.sleep_records.finished.where(wake_time: week_start..week_end).order(:wake_time)
+    # unwoken(未就寝)
+    @unwoken_record = current_user.sleep_records.unbedded.first
 
-    @average_sleep_hours = calculate_average_sleep_hours(finished_records)
-    @average_wake_hours = calculate_average_wake_hours(finished_records)
+    @series = SleepRecord.build_series(@week_records, range: week_start..week_end)
 
-    @weekly_average_sleep_hours = calculate_weekly_average_sleep_hours
-    @weekly_average_wake_hours = calculate_weekly_average_wake_hours
+    week_days = (week_start.to_date..week_end.to_date).to_a
+    @weekly_records = SleepRecord.build_cumulative(@week_records, week_days)
 
-    @average_wake_time = calculate_average_wake_time(sleep_records.with_wake_time)
-    @average_bed_time = calculate_average_bed_time(finished_records)
+    # 平均時間
+    @weekly_average_wake_hours  = SleepRecord.average_wake_hours(@week_records)
+    @weekly_average_sleep_hours = SleepRecord.average_sleep_hours(@week_records)
 
-    @weekly_cumulative_wake_hours = calculate_weekly_cumulative_wake_hours
-    @weekly_cumulative_sleep_hours = calculate_weekly_cumulative_sleep_hours
-  end
-
-  private
-
-  def find_today_sleep_record(records)
-    today = Date.current
-    records.find_by("DATE(wake_time) = ?", today)
-  end
-
-  def calculate_average_sleep_hours(records)
-    return 0.0 if records.empty?
-    total_sleep_hours = SleepRecord.total_sleep_hours(records)
-    (total_sleep_hours / records.size).round(2)
-  end
-
-  def calculate_average_wake_hours(records)
-    return 0.0 if records.empty?
-    total_wake_hours = records.sum { |record| SleepRecord.calculate_daily_wake(record, record) || 0 }
-    (total_wake_hours / records.size).round(2)
-  end
-
-  def calculate_weekly_average_sleep_hours
-    return nil if @weekly_records.empty?
-    sleep_hours = @weekly_records.map { |r| r[:daily_sleep_hours] }.compact
-    return nil if sleep_hours.empty?
-    (sleep_hours.sum / sleep_hours.size).round(2)
-  end
-
-  def calculate_weekly_average_wake_hours
-    return nil if @weekly_records.empty?
-    wake_hours = @weekly_records.map { |r| r[:daily_wake_hours] }.compact
-    return nil if wake_hours.empty?
-    (wake_hours.sum / wake_hours.size).round(2)
-  end
-
-  def calculate_average_wake_time(records)
-    return nil if records.empty?
-    total_seconds = records.sum do |record|
-      time = record.wake_time.in_time_zone
-      time.hour * 3600 + time.min * 60 + time.sec
-    end
-    average_seconds = total_seconds / records.size
-    hours = (average_seconds / 3600).to_i
-    minutes = ((average_seconds % 3600) / 60).to_i
-    hours -= 24 if hours >= 24
-    sprintf("%02d:%02d", hours, minutes)
-  end
-
-  def calculate_average_bed_time(records)
-    return nil if records.empty?
-    total_seconds = records.sum do |record|
-      time = record.bed_time.in_time_zone
-      seconds = time.hour * 3600 + time.min * 60 + time.sec
-      seconds += 24 * 3600 if time.hour < 6  # 深夜0-6時を翌日扱い
-      seconds
-    end
-    average_seconds = total_seconds / records.size
-    average_seconds -= 24 * 3600 if average_seconds >= 24 * 3600
-    hours = (average_seconds / 3600).to_i
-    minutes = ((average_seconds % 3600) / 60).to_i
-    sprintf("%02d:%02d", hours, minutes)
-  end
-
-  def calculate_weekly_cumulative_wake_hours
-    return nil if @weekly_records.empty?
-    latest_record = @weekly_records.last
-    latest_record[:cumulative_wake_hours]&.to_f || 0.0
-  end
-
-  def calculate_weekly_cumulative_sleep_hours
-    return nil if @weekly_records.empty?
-    latest_record = @weekly_records.last
-    latest_record[:cumulative_sleep_hours]&.to_f || 0.0
+    # 平均時刻
+    @weekly_average_wake_time = SleepRecord.average_time(@week_records.with_wake_time, :wake_time)
+    @weekly_average_bed_time  = SleepRecord.average_time(@week_records, :bed_time)
   end
 end

--- a/app/controllers/history_controller.rb
+++ b/app/controllers/history_controller.rb
@@ -2,21 +2,31 @@ class HistoryController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    sleep_records = current_user.sleep_records.order(:bed_time)
-    months = (0..11).map { |i| Date.today.prev_month(i) }.sort.reverse
+    year  = params[:year]&.to_i || Date.current.year
+    month = params[:month]&.to_i || Date.current.month
 
-    @monthly_records_list = []
-    @monthly_series_list = []
+    start_date = Date.new(year, month, 1)
+    end_date   = start_date.end_of_month
 
-    months.each do |month|
-      month_start = month.beginning_of_month
-      month_end = month.end_of_month
-      month_records = sleep_records.select { |r| r.bed_time.to_date >= month_start && r.bed_time.to_date <= month_end }
-      records = SleepRecord.build_monthly_cumulative(month_records, date: month)
-      if records.any? { |r| r[:bed_times].present? || r[:wake_times].present? }
-        @monthly_records_list << { month: month, records: records }
-        @monthly_series_list << { month: month, series: SleepRecord.build_series(month_records) }
-      end
-    end
+    sleep_records = current_user.sleep_records.where(
+      wake_time: start_date.beginning_of_day..end_date.end_of_day
+    ).order(:wake_time)
+    finished_records = sleep_records.finished
+
+    month_days = (start_date..end_date).to_a
+    @monthly_records = SleepRecord.build_cumulative(finished_records, month_days)
+
+    @series = SleepRecord.build_series(sleep_records, range: start_date.beginning_of_day..end_date.end_of_day)
+
+    # 平均時間
+    @month_average_wake_hours  = SleepRecord.average_wake_hours(finished_records)
+    @month_average_sleep_hours = SleepRecord.average_sleep_hours(finished_records)
+
+    # 平均時刻
+    @month_average_wake_time = SleepRecord.average_time(finished_records.with_wake_time, :wake_time)
+    @month_average_bed_time  = SleepRecord.average_time(finished_records, :bed_time)
+
+    @selected_year  = year
+    @selected_month = month
   end
 end

--- a/app/controllers/sleep_records_controller.rb
+++ b/app/controllers/sleep_records_controller.rb
@@ -1,29 +1,43 @@
 class SleepRecordsController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_unwoken_record, only: [ :update ]
+  before_action :set_unwoken_record
 
   def create
-    if @unwoken_record
-      redirect_with_flash(:alert, "すでに未起床レコードがあります") and return
-    end
-
-    current_user.sleep_records.create!(bed_time: Time.current)
-    redirect_with_flash(:notice, "就寝時刻を記録しました")
+    return redirect_with_flash(:alert, "すでに未就寝レコードがあります") if @unwoken_record
+    create_wake_record
   end
 
   def update
-    if @unwoken_record
-      @unwoken_record.update!(wake_time: Time.current)
-      redirect_with_flash(:notice, "起床時刻を記録しました")
-    else
-      redirect_with_flash(:alert, "未起床レコードがありません")
-    end
+    return redirect_with_flash(:alert, "未就寝レコードがありません") unless @unwoken_record
+    update_bed_time
   end
 
   private
 
   def set_unwoken_record
-    @unwoken_record = current_user.sleep_records.unwoken.first
+    @unwoken_record = current_user.sleep_records.unbedded.first
+  end
+
+  def create_wake_record
+    last_record = current_user.sleep_records.order(:wake_time).last
+    if last_record && last_record.bed_time.nil?
+      return redirect_with_flash(:alert, "前回の就寝時刻を先に記録してください")
+    end
+
+    sleep_record = current_user.sleep_records.build(wake_time: Time.current)
+    if sleep_record.save
+      redirect_with_flash(:notice, "起床時刻を記録しました")
+    else
+      redirect_with_flash(:alert, "起床時刻の記録に失敗しました: #{sleep_record.errors.full_messages.join(', ')}")
+    end
+  end
+
+  def update_bed_time
+    if @unwoken_record.update(bed_time: Time.current)
+      redirect_with_flash(:notice, "就寝時刻を記録しました")
+    else
+      redirect_with_flash(:alert, "就寝時刻の記録に失敗しました: #{@unwoken_record.errors.full_messages.join(', ')}")
+    end
   end
 
   def redirect_with_flash(type, message)

--- a/app/models/sleep_record.rb
+++ b/app/models/sleep_record.rb
@@ -77,10 +77,6 @@ class SleepRecord < ApplicationRecord
 
   private
 
-  def wake_time_after_bed_time
-    return if bed_time.blank? || wake_time.blank?
-    if wake_time <= bed_time
-      errors.add(:wake_time, "無効な入力です。起床時間は就寝時間より後に設定してください。")
-    end
+
   end
 end

--- a/app/models/sleep_record.rb
+++ b/app/models/sleep_record.rb
@@ -169,5 +169,19 @@ class SleepRecord < ApplicationRecord
     time.strftime("%m/%d %H:%M")
   end
 
+  # -- バリデーション --
+
+  def bed_time_after_wake_time
+    return if wake_time.blank? || bed_time.blank?
+
+    if bed_time.to_date == wake_time.to_date
+      return if bed_time > wake_time
+    elsif bed_time.to_date == wake_time.to_date + 1.day
+      return
+    elsif bed_time.to_date > wake_time.to_date
+      return
+    end
+
+    errors.add(:bed_time, "無効な入力です。就寝時間は起床時間より後に設定してください。")
   end
 end

--- a/app/models/sleep_record.rb
+++ b/app/models/sleep_record.rb
@@ -59,14 +59,12 @@ class SleepRecord < ApplicationRecord
     series
   end
 
-  def self.build_weekly_cumulative(records, days: 7)
-    today = Date.today
-    start_of_week = today - ((today.wday == 0 ? 6 : today.wday - 1)) # 月曜始まり
-    cutoff = start_of_week.beginning_of_day
-    end_of_week = (start_of_week + days).beginning_of_day
-    recent_records = records.select { |r| r.bed_time >= cutoff && r.bed_time < end_of_week }
-    week_days = (0...days).map { |i| start_of_week + i }
-    build_cumulative(recent_records, week_days)
+  def self.total_sleep_hours(records)
+    return 0.0 if records.empty?
+
+    ordered_records = records.with_wake_time.order(:wake_time)
+    cumulative_sleep, _ = calculate_cumulative_times(ordered_records)
+    cumulative_sleep
   end
 
   private

--- a/app/models/sleep_record.rb
+++ b/app/models/sleep_record.rb
@@ -111,5 +111,17 @@ class SleepRecord < ApplicationRecord
       cumulative_wake_hours: format_cumulative(cumulative_wake)
     }
   end
+
+  def self.build_empty_day_data(day, cumulative_sleep, cumulative_wake)
+    {
+      day: day,
+      wake_times: [],
+      bed_times: [],
+      daily_sleep_hours: nil,
+      daily_wake_hours: nil,
+      cumulative_sleep_hours: nil,
+      cumulative_wake_hours: nil
+    }
+  end
   end
 end

--- a/app/models/sleep_record.rb
+++ b/app/models/sleep_record.rb
@@ -77,6 +77,24 @@ class SleepRecord < ApplicationRecord
 
   private
 
+  def self.calculate_cumulative_times(records)
+    return [ 0.0, 0.0 ] if records.empty?
 
+    cumulative_sleep = 0.0
+    cumulative_wake = 0.0
+    ordered_records = records.is_a?(ActiveRecord::Relation) ? records.to_a : records
+
+    ordered_records.each_with_index do |record, index|
+      end_time = record.bed_time || Time.current
+      cumulative_wake += time_diff_hours(record.wake_time, end_time)
+
+      next_record = ordered_records[index + 1]
+      if record.bed_time && next_record
+        cumulative_sleep += time_diff_hours(record.bed_time, next_record.wake_time)
+      end
+    end
+
+    [ cumulative_sleep, cumulative_wake ]
+  end
   end
 end

--- a/app/models/sleep_record.rb
+++ b/app/models/sleep_record.rb
@@ -67,6 +67,14 @@ class SleepRecord < ApplicationRecord
     cumulative_sleep
   end
 
+  def self.total_wake_hours(records)
+    return 0.0 if records.empty?
+
+    ordered_records = records.with_wake_time.order(:wake_time)
+    _, cumulative_wake = calculate_cumulative_times(ordered_records)
+    cumulative_wake
+  end
+
   private
 
   def wake_time_after_bed_time

--- a/app/models/sleep_record.rb
+++ b/app/models/sleep_record.rb
@@ -145,5 +145,15 @@ class SleepRecord < ApplicationRecord
     start_of_week.beginning_of_day...(start_of_week + days.days).beginning_of_day
   end
 
+  # 時間差計算（日跨ぎ対応）
+  def self.time_diff_hours(start_time, end_time)
+    return 0.0 unless start_time && end_time
+
+    seconds = end_time.to_time - start_time.to_time
+    hours = seconds / 3600.0
+    result = [ hours, 0.0 ].max.round(2)
+
+    result
+  end
   end
 end

--- a/app/models/sleep_record.rb
+++ b/app/models/sleep_record.rb
@@ -155,5 +155,19 @@ class SleepRecord < ApplicationRecord
 
     result
   end
+
+  # -- フォーマット --
+
+  def self.format_cumulative(value)
+    return nil unless value.positive?
+    formatted = value.round(2)
+    formatted % 1 == 0 ? formatted.to_i.to_s : sprintf("%.2f", formatted)
+  end
+
+  def self.format_time(time)
+    return nil unless time
+    time.strftime("%m/%d %H:%M")
+  end
+
   end
 end

--- a/app/models/sleep_record.rb
+++ b/app/models/sleep_record.rb
@@ -1,4 +1,13 @@
 class SleepRecord < ApplicationRecord
+  belongs_to :user
+
+  validates :wake_time, presence: true
+  validate :bed_time_after_wake_time
+
+  scope :unbedded, -> { where(bed_time: nil) }
+  scope :with_wake_time, -> { where.not(wake_time: nil) }
+  scope :finished, -> { where.not(bed_time: nil) }
+
   def self.build_cumulative(records, days_range)
   grouped = records.group_by { |r| r.wake_time&.to_date || r.bed_time.to_date }
 

--- a/app/models/sleep_record.rb
+++ b/app/models/sleep_record.rb
@@ -123,5 +123,27 @@ class SleepRecord < ApplicationRecord
       cumulative_wake_hours: nil
     }
   end
+
+  def self.calculate_daily_sleep(first_record, all_records)
+    index = all_records.index(first_record)
+    return nil unless index&.positive?
+
+    prev_record = all_records[index - 1]
+    return nil unless prev_record.bed_time
+
+    time_diff_hours(prev_record.bed_time, first_record.wake_time)
+  end
+
+  def self.calculate_daily_wake(first_record, last_record)
+    end_time = last_record.bed_time || Time.current
+    time_diff_hours(first_record.wake_time, end_time)
+  end
+
+  def self.get_week_range(days)
+    today = Date.current
+    start_of_week = today.beginning_of_week(:monday)
+    start_of_week.beginning_of_day...(start_of_week + days.days).beginning_of_day
+  end
+
   end
 end

--- a/app/models/sleep_record.rb
+++ b/app/models/sleep_record.rb
@@ -8,182 +8,198 @@ class SleepRecord < ApplicationRecord
   scope :with_wake_time, -> { where.not(wake_time: nil) }
   scope :finished, -> { where.not(bed_time: nil) }
 
+  def self.average_sleep_hours(records)
+    return 0.0 if records.empty?
+    (total_sleep_hours(records) / records.size).round(2)
+  end
+
+  def self.average_wake_hours(records)
+    return 0.0 if records.empty?
+    (total_wake_hours(records) / records.size).round(2)
+  end
+
+  def self.average_time(records, column)
+    return nil if records.empty?
+
+    total_seconds = records.sum do |r|
+      t = r.send(column)
+      next 0 unless t
+
+      sec = t.hour * 3600 + t.min * 60 + t.sec
+      sec += 24 * 3600 if column == :bed_time && t.hour < 6
+      sec
+    end
+
+    avg_sec = total_seconds / records.size
+    avg_sec -= 24 * 3600 if avg_sec >= 24 * 3600
+
+    hours = (avg_sec / 3600).to_i
+    minutes = ((avg_sec % 3600) / 60).to_i
+    sprintf("%02d:%02d", hours, minutes)
+  end
+
+
+  def self.total_sleep_hours(records)
+    cumulative_times(records).first
+  end
+
+  def self.total_wake_hours(records)
+    cumulative_times(records).last
+  end
+
+
+  # 日別累計
   def self.build_cumulative(records, days_range)
     return [] if records.empty?
 
-    sorted_records = records.with_wake_time.order(:wake_time)
+    sorted = records.with_wake_time.order(:wake_time)
     records_by_date = records.group_by { |r| r.wake_time&.to_date }.compact
 
     days_range.map do |day|
       day_records = records_by_date[day] || []
-      records_until_day = sorted_records.where("wake_time <= ?", day.end_of_day)
-
-      cumulative_sleep, cumulative_wake = calculate_cumulative_times(records_until_day)
+      until_day_records = sorted.select { |r| r.wake_time <= day.end_of_day }
+      sleep_total, wake_total = cumulative_times(until_day_records)
 
       if day_records.any?
-        build_day_data(day_records, sorted_records, cumulative_sleep, cumulative_wake)
+        build_day_data(day_records, sorted, sleep_total, wake_total)
       else
-        build_empty_day_data(day, cumulative_sleep, cumulative_wake)
+        build_empty_day_data(day, sleep_total, wake_total)
       end
     end
   end
 
-  def self.build_weekly_cumulative(records, days: 7)
-    week_range = get_week_range(days)
-    recent_records = records.where(wake_time: week_range)
-    week_days = week_range.begin.to_date..(week_range.begin.to_date + days - 1)
-    build_cumulative(recent_records, week_days.to_a)
-  end
+  # グラフ用データ
+  def self.build_series(records, range: nil, days: nil)
+    filtered = if range
+      records.where(wake_time: range)
+    elsif days
+      records.where(wake_time: get_week_range(days))
+    else
+      records
+    end
+    ordered = filtered.with_wake_time.order(:wake_time)
 
-  def self.build_series(records, days: nil)
-    filtered_records = days ? records.where(wake_time: get_week_range(days)) : records
-    ordered_records = filtered_records.with_wake_time.order(:wake_time)
-
-    cumulative_value = 0.0
     series = []
+    cumulative = 0.0
 
-    ordered_records.includes(:user).each_with_index do |record, index|
-      series << [ record.wake_time.iso8601, cumulative_value ]
+    ordered.each_with_index do |record, i|
+      series << [ record.wake_time.iso8601, cumulative ]
 
       bed_time = record.bed_time || Time.current
       awake_hours = time_diff_hours(record.wake_time, bed_time)
-      cumulative_value += awake_hours
-      series << [ bed_time.iso8601, cumulative_value ]
+      cumulative += awake_hours
+      series << [ bed_time.iso8601, cumulative ]
 
-      next_record = ordered_records[index + 1]
-      if next_record&.wake_time && record.bed_time
-        sleep_hours = time_diff_hours(record.bed_time, next_record.wake_time)
-        cumulative_value -= sleep_hours
-        series << [ next_record.wake_time.iso8601, cumulative_value ]
+      next_rec = ordered[i + 1]
+      if record.bed_time && next_rec&.wake_time
+        sleep_hours = time_diff_hours(record.bed_time, next_rec.wake_time)
+        cumulative -= sleep_hours
+        series << [ next_rec.wake_time.iso8601, cumulative ]
       end
     end
 
     series
   end
 
-  def self.total_sleep_hours(records)
-    return 0.0 if records.empty?
-
-    ordered_records = records.with_wake_time.order(:wake_time)
-    cumulative_sleep, _ = calculate_cumulative_times(ordered_records)
-    cumulative_sleep
-  end
-
-  def self.total_wake_hours(records)
-    return 0.0 if records.empty?
-
-    ordered_records = records.with_wake_time.order(:wake_time)
-    _, cumulative_wake = calculate_cumulative_times(ordered_records)
-    cumulative_wake
-  end
-
   private
 
-  def self.calculate_cumulative_times(records)
-    return [ 0.0, 0.0 ] if records.empty?
+    # 日別データ
+    def self.build_day_data(day_records, all_records, cumulative_sleep, cumulative_wake)
+      first = day_records.min_by(&:wake_time)
+      last = day_records.max_by(&:wake_time)
 
-    cumulative_sleep = 0.0
-    cumulative_wake = 0.0
-    ordered_records = records.is_a?(ActiveRecord::Relation) ? records.to_a : records
+      {
+        day: first.wake_time.to_date,
+        wake_times: [ format_time(first.wake_time) ],
+        bed_times: last.bed_time ? [ format_time(last.bed_time) ] : [],
+        daily_sleep_hours: daily_sleep(first, all_records),
+        daily_wake_hours: daily_wake(first, last),
+        cumulative_sleep_hours: format_cumulative(cumulative_sleep),
+        cumulative_wake_hours: format_cumulative(cumulative_wake)
+      }
+    end
 
-    ordered_records.each_with_index do |record, index|
-      end_time = record.bed_time || Time.current
-      cumulative_wake += time_diff_hours(record.wake_time, end_time)
+    def self.build_empty_day_data(day, cumulative_sleep, cumulative_wake)
+      {
+        day: day,
+        wake_times: [],
+        bed_times: [],
+        daily_sleep_hours: nil,
+        daily_wake_hours: nil,
+        cumulative_sleep_hours: nil,
+        cumulative_wake_hours: nil
+      }
+    end
 
-      next_record = ordered_records[index + 1]
-      if record.bed_time && next_record
-        cumulative_sleep += time_diff_hours(record.bed_time, next_record.wake_time)
+    # 日ごとの睡眠/活動
+    def self.daily_sleep(first, all_records)
+      idx = all_records.index(first)
+      return nil unless idx&.positive?
+
+      prev = all_records[idx - 1]
+      return nil unless prev.bed_time
+
+      time_diff_hours(prev.bed_time, first.wake_time)
+    end
+
+    def self.daily_wake(first, last)
+      end_time = last.bed_time || Time.current
+      time_diff_hours(first.wake_time, end_time)
+    end
+
+    # 総睡眠・総起床計算
+    def self.cumulative_times(records)
+      return [ 0.0, 0.0 ] if records.empty?
+
+      sleep_total = 0.0
+      wake_total = 0.0
+      ordered = records.is_a?(ActiveRecord::Relation) ? records.to_a : records
+
+      ordered.each_with_index do |rec, i|
+        end_time = rec.bed_time || Time.current
+        wake_total += time_diff_hours(rec.wake_time, end_time)
+
+        next_rec = ordered[i + 1]
+        sleep_total += time_diff_hours(rec.bed_time, next_rec.wake_time) if rec.bed_time && next_rec
       end
+
+      [ sleep_total, wake_total ]
     end
 
-    [ cumulative_sleep, cumulative_wake ]
-  end
+    # 時間差計算（hours, 2桁で丸め）
+    def self.time_diff_hours(start_time, end_time)
+      return 0.0 unless start_time && end_time
 
-  def self.build_day_data(day_records, all_records, cumulative_sleep, cumulative_wake)
-    first_record = day_records.min_by(&:wake_time)
-    last_record = day_records.max_by(&:wake_time)
-
-    {
-      day: first_record.wake_time.to_date,
-      wake_times: [ format_time(first_record.wake_time) ],
-      bed_times: last_record.bed_time ? [ format_time(last_record.bed_time) ] : [],
-      daily_sleep_hours: calculate_daily_sleep(first_record, all_records),
-      daily_wake_hours: calculate_daily_wake(first_record, last_record),
-      cumulative_sleep_hours: format_cumulative(cumulative_sleep),
-      cumulative_wake_hours: format_cumulative(cumulative_wake)
-    }
-  end
-
-  def self.build_empty_day_data(day, cumulative_sleep, cumulative_wake)
-    {
-      day: day,
-      wake_times: [],
-      bed_times: [],
-      daily_sleep_hours: nil,
-      daily_wake_hours: nil,
-      cumulative_sleep_hours: nil,
-      cumulative_wake_hours: nil
-    }
-  end
-
-  def self.calculate_daily_sleep(first_record, all_records)
-    index = all_records.index(first_record)
-    return nil unless index&.positive?
-
-    prev_record = all_records[index - 1]
-    return nil unless prev_record.bed_time
-
-    time_diff_hours(prev_record.bed_time, first_record.wake_time)
-  end
-
-  def self.calculate_daily_wake(first_record, last_record)
-    end_time = last_record.bed_time || Time.current
-    time_diff_hours(first_record.wake_time, end_time)
-  end
-
-  def self.get_week_range(days)
-    today = Date.current
-    start_of_week = today.beginning_of_week(:monday)
-    start_of_week.beginning_of_day...(start_of_week + days.days).beginning_of_day
-  end
-
-  # 時間差計算（日跨ぎ対応）
-  def self.time_diff_hours(start_time, end_time)
-    return 0.0 unless start_time && end_time
-
-    seconds = end_time.to_time - start_time.to_time
-    hours = seconds / 3600.0
-    result = [ hours, 0.0 ].max.round(2)
-
-    result
-  end
-
-  # -- フォーマット --
-
-  def self.format_cumulative(value)
-    return nil unless value.positive?
-    formatted = value.round(2)
-    formatted % 1 == 0 ? formatted.to_i.to_s : sprintf("%.2f", formatted)
-  end
-
-  def self.format_time(time)
-    return nil unless time
-    time.strftime("%m/%d %H:%M")
-  end
-
-  # -- バリデーション --
-
-  def bed_time_after_wake_time
-    return if wake_time.blank? || bed_time.blank?
-
-    if bed_time.to_date == wake_time.to_date
-      return if bed_time > wake_time
-    elsif bed_time.to_date == wake_time.to_date + 1.day
-      return
-    elsif bed_time.to_date > wake_time.to_date
-      return
+      seconds = end_time.to_time - start_time.to_time
+      [ (seconds / 3600.0).round(2), 0.0 ].max
     end
 
-    errors.add(:bed_time, "無効な入力です。就寝時間は起床時間より後に設定してください。")
-  end
+    def self.format_time(time)
+      time&.strftime("%m/%d %H:%M")
+    end
+
+    def self.format_cumulative(value)
+      return nil unless value.positive?
+      v = value.round(2)
+      v % 1 == 0 ? v.to_i.to_s : sprintf("%.2f", v)
+    end
+
+    def self.get_week_range(days)
+      today = Date.current
+      start_of_week = today.beginning_of_week(:monday)
+      start_of_week.beginning_of_day...(start_of_week + days.days).beginning_of_day
+    end
+
+
+    def bed_time_after_wake_time
+      return if wake_time.blank? || bed_time.blank?
+
+      if bed_time >= wake_time
+        return
+      elsif bed_time.to_date > wake_time.to_date
+        return
+      end
+
+      errors.add(:bed_time, "無効な入力です。就寝時間は起床時間より後に設定してください。")
+    end
 end

--- a/app/models/sleep_record.rb
+++ b/app/models/sleep_record.rb
@@ -20,9 +20,11 @@ class SleepRecord < ApplicationRecord
 
       cumulative_sleep, cumulative_wake = calculate_cumulative_times(records_until_day)
 
-      day_records.any? ?
-        build_day_data(day_records, sorted_records, cumulative_sleep, cumulative_wake) :
+      if day_records.any?
+        build_day_data(day_records, sorted_records, cumulative_sleep, cumulative_wake)
+      else
         build_empty_day_data(day, cumulative_sleep, cumulative_wake)
+      end
     end
   end
 

--- a/app/models/sleep_record.rb
+++ b/app/models/sleep_record.rb
@@ -96,5 +96,20 @@ class SleepRecord < ApplicationRecord
 
     [ cumulative_sleep, cumulative_wake ]
   end
+
+  def self.build_day_data(day_records, all_records, cumulative_sleep, cumulative_wake)
+    first_record = day_records.min_by(&:wake_time)
+    last_record = day_records.max_by(&:wake_time)
+
+    {
+      day: first_record.wake_time.to_date,
+      wake_times: [ format_time(first_record.wake_time) ],
+      bed_times: last_record.bed_time ? [ format_time(last_record.bed_time) ] : [],
+      daily_sleep_hours: calculate_daily_sleep(first_record, all_records),
+      daily_wake_hours: calculate_daily_wake(first_record, last_record),
+      cumulative_sleep_hours: format_cumulative(cumulative_sleep),
+      cumulative_wake_hours: format_cumulative(cumulative_wake)
+    }
+  end
   end
 end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,6 +1,5 @@
 <div class="min-h-screen">
   <div class="container mx-auto p-8">
-
     <div class="navbar mb-8">
       <div class="navbar-start">
         <h1 class="text-5xl font-bold text-base-content">Dashboard</h1>
@@ -11,25 +10,22 @@
         </span>
       </div>
     </div>
-
     <div class="flex flex-col lg:flex-row gap-6 mb-8">
       <!-- 左カラム -->
       <div class="w-full lg:flex-[7] flex flex-col gap-4">
-
         <!-- グラフ -->
         <div class="card bg-base-100 border border-base-300">
           <div class="card-body p-6">
             <div class="flex items-center justify-between mb-4">
-              <h3 class="text-2xl font-bold">活動パターン</h3>
+              <h3 class="text-2xl font-bold">活動グラフ</h3>
               <span class="badge badge-outline">１週間</span>
             </div>
             <div id="sleep-chart"
-                data-series='<%= @series.to_json.html_safe %>'
-                style="height: 350px;">
+              data-series='<%= @series.to_json.html_safe %>'
+              style="height: 350px;">
             </div>
           </div>
         </div>
-
         <!-- 統計 -->
         <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
           <div class="card bg-base-100 border border-base-300 text-center p-4">

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,39 +1,203 @@
-<div class="flex justify-center gap-4 mt-10 mb-10">
-  <%= button_to "就寝", sleep_records_path, method: :post, class: "btn btn-lg", disabled: @unwoken_record.present? %>
-  <%= button_to "起床", (@unwoken_record ? sleep_record_path(@unwoken_record) : "#"), method: :patch, class: "btn btn-lg", disabled: @unwoken_record.nil? %>
+<div class="min-h-screen">
+  <div class="container mx-auto p-8">
+
+    <div class="navbar mb-8">
+      <div class="navbar-start">
+        <h1 class="text-5xl font-bold text-base-content">Dashboard</h1>
+      </div>
+      <div class="navbar-end flex gap-2 items-center">
+        <span class="text-base-content/70 text-sm">
+          <%= t('navbar.welcome', name: current_user.name) %>
+        </span>
+      </div>
+    </div>
+
+    <div class="flex flex-col lg:flex-row gap-6 mb-8">
+      <!-- 左カラム -->
+      <div class="w-full lg:flex-[7] flex flex-col gap-4">
+
+        <!-- グラフ -->
+        <div class="card bg-base-100 border border-base-300">
+          <div class="card-body p-6">
+            <div class="flex items-center justify-between mb-4">
+              <h3 class="text-2xl font-bold">活動パターン</h3>
+              <span class="badge badge-outline">１週間</span>
+            </div>
+            <div id="sleep-chart"
+                data-series='<%= @series.to_json.html_safe %>'
+                style="height: 350px;">
+            </div>
+          </div>
+        </div>
+
+        <!-- 統計 -->
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+          <div class="card bg-base-100 border border-base-300 text-center p-4">
+            <div class="text-xs text-base-content/70 mb-2">週/平均活動時間</div>
+            <div class="text-2xl font-bold text-success">
+              <%= @weekly_average_wake_hours ? sprintf("%.1f", @weekly_average_wake_hours) : '-' %>h
+            </div>
+          </div>
+          <div class="card bg-base-100 border border-base-300 text-center p-4">
+            <div class="text-xs text-base-content/70 mb-2">週/平均睡眠時間</div>
+            <div class="text-2xl font-bold text-info">
+              <%= @weekly_average_sleep_hours ? sprintf("%.1f", @weekly_average_sleep_hours) : '-' %>h
+            </div>
+          </div>
+          <div class="card bg-base-100 border border-base-300 text-center p-4">
+            <div class="text-xs text-base-content/70 mb-2">週/平均起床時刻</div>
+            <div class="text-2xl font-bold text-primary">
+              <%= @average_wake_time || "--:--" %>
+            </div>
+          </div>
+          <div class="card bg-base-100 border border-base-300 text-center p-4">
+            <div class="text-xs text-base-content/70 mb-2">週/平均就寝時刻</div>
+            <div class="text-2xl font-bold text-secondary">
+              <%= @average_bed_time || "--:--" %>
+            </div>
+          </div>
+        </div>
+
+        <!-- 記録テーブル -->
+      <div class="card bg-base-100 border border-base-300">
+        <details class="group [&_summary::-webkit-details-marker]:hidden">
+          <summary class="cursor-pointer p-4 font-bold text-xl bg-base-100 flex justify-between items-center rounded-t-lg">
+            1週間分の記録
+            <span class="transition-transform duration-300 group-open:rotate-180">⤵︎</span>
+          </summary>
+          <div class="overflow-x-auto p-4">
+            <table class="table table-zebra w-full border-t border-base-300">
+              <thead class="bg-base-200">
+                <tr>
+                  <th class="px-4 py-3 text-sm font-semibold text-base-content/70">日付</th>
+                  <th class="px-4 py-3 text-sm font-semibold text-base-content/70">起床時刻</th>
+                  <th class="px-4 py-3 text-sm font-semibold text-base-content/70">就寝時刻</th>
+                  <th class="px-4 py-3 text-sm font-semibold text-base-content/70">活動時間（h）</th>
+                  <th class="px-4 py-3 text-sm font-semibold text-base-content/70">睡眠時間（h）</th>
+                  <th class="px-4 py-3 text-sm font-semibold text-base-content/70">週累計活動（h）</th>
+                  <th class="px-4 py-3 text-sm font-semibold text-base-content/70">週累計睡眠（h）</th>
+                </tr>
+              </thead>
+              <tbody>
+                <% @weekly_records.each_with_index do |record, idx| %>
+                  <tr class="hover">
+                    <td class="px-4 py-3">
+                      <%= record[:day].is_a?(Date) ? record[:day].strftime("%m-%d (%a)") : '--' %>
+                    </td>
+                    <td class="px-4 py-3">
+                      <% if record[:wake_times].present? %>
+                        <% record[:wake_times].each do |time| %>
+                          <span class="badge badge-success badge-sm block mb-1">
+                            <%= time.split(' ').last %>
+                          </span>
+                        <% end %>
+                      <% else %>
+                        <span class="text-base-content/40">-</span>
+                      <% end %>
+                    </td>
+                    <td class="px-4 py-3">
+                      <% if record[:bed_times].present? %>
+                        <% record[:bed_times].each do |time| %>
+                          <span class="badge badge-secondary badge-sm block mb-1">
+                            <%= time.split(' ').last %>
+                          </span>
+                        <% end %>
+                      <% else %>
+                        <span class="text-base-content/40">-</span>
+                      <% end %>
+                    </td>
+                    <td class="px-4 py-3 text-accent font-semibold">
+                      <%= record[:daily_wake_hours] ? sprintf("%.1f", record[:daily_wake_hours]) : '-' %>
+                    </td>
+                    <td class="px-4 py-3 text-info font-semibold">
+                      <%= record[:daily_sleep_hours] ? sprintf("%.1f", record[:daily_sleep_hours]) : '-' %>
+                    </td>
+                    <td class="px-4 py-3 text-accent text-sm font-semibold">
+                      <%= record[:cumulative_wake_hours] || '-' %>
+                    </td>
+                    <td class="px-4 py-3 text-info text-sm font-semibold">
+                      <%= record[:cumulative_sleep_hours] || '-' %>
+                    </td>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
+          </div>
+        </details>
+      </div>
+
+
+      </div>
+
+      <!-- 右カラム -->
+      <div class="w-full lg:flex-[3] flex flex-col gap-6">
+
+        <!-- 記録カード -->
+        <div class="h-[240px] card bg-base-100 border border-base-300">
+          <div class="card-body p-4 flex flex-col justify-between">
+            <div class="text-center p-3 bg-base-200">
+              <div class="text-2xl font-mono font-bold text-base-content">
+                <%= Time.current.strftime("%H:%M") %>
+              </div>
+              <div class="text-xs text-base-content/70">
+                <%= Time.current.strftime("%Y/%m/%d") %>
+              </div>
+            </div>
+
+            <div class="space-y-3">
+              <%= button_to "起床記録", sleep_records_path,
+                  method: :post,
+                  class: "btn btn-primary btn-lg w-full #{'btn-disabled' if @unwoken_record.present?}",
+                  disabled: @unwoken_record.present? %>
+              <%= button_to "就寝記録",
+                  (@unwoken_record ? sleep_record_path(@unwoken_record) : "#"),
+                  method: :patch,
+                  class: "btn btn-secondary btn-lg w-full #{'btn-disabled' if @unwoken_record.nil?}",
+                  disabled: @unwoken_record.nil? %>
+            </div>
+          </div>
+        </div>
+
+        <!-- タスクエリア 仮作成 -->
+        <%# <div class="h-[360px] overflow-y-auto ">
+          <div class="card-body p-6">
+            <h3 class="text-2xl font-bold mb-6">今日のタスク</h3>
+
+            <div class="space-y-3">
+              <div class="card bg-base-100">
+                <div class="card-body flex-row items-center gap-3 p-3">
+                  <input type="checkbox" class="checkbox checkbox-primary" />
+                  <span class="flex-1">睡眠時間を8時間確保する</span>
+                  <span class="badge badge-primary badge-sm">重要</span>
+                </div>
+              </div>
+
+              <div class="card bg-base-100">
+                <div class="card-body flex-row items-center gap-3 p-3">
+                  <input type="checkbox" class="checkbox checkbox-secondary" />
+                  <span class="flex-1">就寝前のスマホ使用を控える</span>
+                  <span class="badge badge-secondary badge-sm">習慣</span>
+                </div>
+              </div>
+
+              <div class="card bg-base-100">
+                <div class="card-body flex-row items-center gap-3 p-3">
+                  <input type="checkbox" class="checkbox checkbox-accent" />
+                  <span class="flex-1">リラックスタイムを設ける</span>
+                  <span class="badge badge-accent badge-sm">推奨</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-6">
+              <button class="btn btn-outline btn-sm w-full">
+                + 新しいタスクを追加
+              </button>
+            </div>
+          </div>
+        </div> %>
+
+      </div>
+    </div>
+  </div>
 </div>
-
-<h2 class="text-xl font-bold mt-6 text-center">起床・睡眠グラフ</h2>
-<div id="sleep-chart" data-series='<%= @series.to_json.html_safe %>'></div>
-
-<h2 class="text-xl font-bold mt-6 text-center">睡眠/起床記録（1週間）</h2>
-<table class="table w-full">
-  <thead>
-    <tr>
-      <th>日付</th>
-      <th>就寝時刻</th>
-      <th>起床時刻</th>
-      <th>週/睡眠時間（h）</th>
-      <th>週/起床時間（h）</th>
-      <th>週/活動時間（h）</th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @weekly_records.each do |record| %>
-      <tr>
-  <td><%= record[:day].strftime("%Y-%m-%d（%a）") %></td>
-        <td><%= record[:bed_times].present? ? record[:bed_times].join(", ") : '-' %></td>
-        <td><%= record[:wake_times].present? ? record[:wake_times].join(", ") : '-' %></td>
-        <td><%= record[:cumulative_sleep_hours].nil? ? '-' : record[:cumulative_sleep_hours] %></td>
-        <td><%= record[:cumulative_wake_hours].nil? ? '-' : record[:cumulative_wake_hours] %></td>
-        <td>
-          <% if record[:cumulative_sleep_hours] && record[:cumulative_wake_hours] %>
-            <%= (record[:cumulative_wake_hours] - record[:cumulative_sleep_hours]).round(2) %>
-          <% else %>
-            -
-          <% end %>
-        </td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>


### PR DESCRIPTION
就寝ベースの記録から起床ベースの記録方法に変更
- 起床時間を基準にすることで、新規ユーザーも起床ボタンから簡単に記録可能になりUXが向上。
- 起床→就寝の流れで記録することで、将来的にタスク機能や時間管理機能で利用しやすくなる設計。
