### PR TITLE
Update/profile edit spec

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -14,7 +14,16 @@ class UsersController < ApplicationController
     if @user.update(user_params)
       redirect_to profile_path, notice: I18n.t("profiles.update.success")
     else
-      redirect_to edit_profile_path, alert: I18n.t("profiles.update.error")
+        if @user.errors[:avatar].present?
+          flash[:alert] = I18n.t("profiles.update.avatar_error")
+        elsif @user.errors[:name].include?(I18n.t("errors.messages.blank"))
+          flash[:alert] = I18n.t("profiles.update.name_error")
+        elsif @user.errors[:name].any? { |msg| msg.include?(I18n.t("errors.messages.too_long", count: 20)) }
+          flash[:alert] = I18n.t("profiles.update.name_length_error")
+        else
+          flash[:alert] = I18n.t("profiles.update.error")
+        end
+      redirect_to edit_profile_path
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ApplicationRecord
 
   has_many :sleep_records, dependent: :destroy
 
-  validates :name, presence: true
+  validates :name, presence: true, length: { maximum: 20 }
 
   # 新規登録時は選択しないため更新時のみバリデーションを行う
   validates :avatar, presence: true, on: :update

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -50,6 +50,9 @@ ja:
     update:
       success: "プロフィールを更新しました"
       error: "プロフィールの更新に失敗しました"
+      avatar_error: "プロフィールアイコンを選択してください"
+      name_error: "名前を入力してください"
+      name_length_error: "名前は20文字以内で入力してください"
   navbar:
     welcome: "ようこそ, %{name} さん"
     profile: "プロフィール"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,6 +10,22 @@ RSpec.describe User, type: :model do
       end
     end
 
+    context "名前が空欄の場合" do
+      it "バリデーションに失敗し、エラーメッセージが正しいこと" do
+        user = FactoryBot.build(:user, name: "")
+        expect(user).not_to be_valid
+        expect(user.errors[:name]).to include(I18n.t("errors.messages.blank"))
+      end
+    end
+
+    context "名前が21文字以上の場合" do
+      it "バリデーションに失敗し、エラーメッセージが正しいこと" do
+        user = FactoryBot.build(:user, name: "あ" * 21)
+        expect(user).not_to be_valid
+        expect(user.errors[:name]).to include(I18n.t("errors.messages.too_long", count: 20))
+      end
+    end
+
     context "メールアドレスがない場合" do
       it "バリデーションに失敗すること" do
         user = FactoryBot.build(:user, email: nil)

--- a/spec/system/profile_edit_spec.rb
+++ b/spec/system/profile_edit_spec.rb
@@ -3,15 +3,15 @@ require 'rails_helper'
 RSpec.describe "プロフィール編集", type: :system do
   let(:user) { FactoryBot.create(:user) }
 
-  describe "アクセス制御" do
-    scenario "未ログインで編集ページにアクセスするとログイン画面へリダイレクト" do
+  context "未ログイン時" do
+    it "編集ページにアクセスするとログイン画面へリダイレクト" do
       visit edit_profile_path
       expect(page).to have_current_path(new_user_session_path)
       expect(page).to have_content(I18n.t('devise.failure.unauthenticated'))
     end
   end
 
-  describe "編集フォーム" do
+  context "ログイン済みで編集ページにアクセスした場合" do
     before do
       visit new_user_session_path
       fill_in I18n.t('activerecord.attributes.user.email'), with: user.email
@@ -20,39 +20,71 @@ RSpec.describe "プロフィール編集", type: :system do
       visit edit_profile_path
     end
 
-    scenario "編集フォームと現在のプロフィール情報が表示される" do
+    it "編集フォームと現在のプロフィール情報が表示される" do
       expect(page).to have_content(I18n.t('profiles.edit.page_title'))
       expect(page).to have_field(I18n.t('profiles.edit.name_label'), with: user.name)
     end
 
-    scenario "有効な名前を入力して保存すると成功メッセージと新しい名前が表示される" do
-      fill_in I18n.t('profiles.edit.name_label'), with: "新しい名前"
-      choose 'boy-1', allow_label_click: true
-      click_button I18n.t('profiles.edit.submit')
+    context "有効な入力の場合" do
+      it "有効な名前を入力して保存すると成功メッセージと新しい名前が表示される" do
+        fill_in I18n.t('profiles.edit.name_label'), with: "新しい名前"
+        choose 'boy-1', allow_label_click: true
+        click_button I18n.t('profiles.edit.submit')
 
-      expect(page).to have_content(I18n.t('profiles.update.success'))
-      expect(page).to have_content("新しい名前")
+        expect(page).to have_content(I18n.t('profiles.update.success'))
+        expect(page).to have_content("新しい名前")
+      end
+
+      it "プリセット画像(boy-1)を選択して保存すると成功メッセージとプロフィールが更新される" do
+        choose 'boy-1', allow_label_click: true
+        click_button I18n.t('profiles.edit.submit')
+
+        expect(page).to have_content(I18n.t('profiles.update.success'))
+        expect(page).to have_selector("img[alt='#{I18n.t('profiles.edit.avatar_label')}'][src*='boy-1']")
+      end
+
+      it "ユーザー名を変更できる" do
+        fill_in I18n.t('activerecord.attributes.user.name'), with: "新しい名前"
+        choose 'boy-1', allow_label_click: true
+        click_button I18n.t('profiles.edit.submit')
+        expect(page).to have_content("新しい名前")
+      end
     end
 
-    scenario "名前を空欄で保存するとエラーメッセージが表示される" do
-      fill_in I18n.t('profiles.edit.name_label'), with: ""
-      click_button I18n.t('profiles.edit.submit')
+    context "無効な入力の場合" do
+      it "プリセット未選択で保存するとエラーメッセージが表示され、更新されない" do
+        click_button I18n.t('profiles.edit.submit')
 
-      expect(page).to have_content(I18n.t('profiles.update.error'))
-    end
+        expect(page).to have_content(I18n.t('profiles.update.avatar_error'))
+      end
 
-    scenario "プリセット画像(boy-1)を選択して保存すると成功メッセージとプロフィールが更新される" do
-      choose 'boy-1', allow_label_click: true
-      click_button I18n.t('profiles.edit.submit')
+      it "最大(20)文字数を超える名前は変更できない" do
+        long_name = 'あ' * 21
+        fill_in I18n.t('activerecord.attributes.user.name'), with: long_name
+        choose 'boy-1', allow_label_click: true
+        click_button I18n.t('profiles.edit.submit')
+        expect(page).to have_content(I18n.t('profiles.update.name_length_error', count: 20))
+      end
 
-      expect(page).to have_content(I18n.t('profiles.update.success'))
-      expect(page).to have_selector("img[alt='#{I18n.t('profiles.edit.avatar_label')}'][src*='boy-1']")
-    end
+      it "空の名前は変更できない" do
+        fill_in I18n.t('activerecord.attributes.user.name'), with: ""
+        choose 'boy-1', allow_label_click: true
+        click_button I18n.t('profiles.edit.submit')
+        expect(page).to have_content(I18n.t('profiles.update.name_error'))
+      end
 
-    scenario "プリセット未選択で保存するとエラーメッセージが表示され、更新されない" do
-      click_button I18n.t('profiles.edit.submit')
+      it "登録時のバリデーションと整合性が保たれる" do
+        fill_in I18n.t('activerecord.attributes.user.name'), with: ""
+        choose 'boy-1', allow_label_click: true
+        click_button I18n.t('profiles.edit.submit')
+        expect(page).to have_content(I18n.t('profiles.update.name_error'))
 
-      expect(page).to have_content(I18n.t('profiles.update.error'))
+        long_name = 'あ' * 21
+        fill_in I18n.t('activerecord.attributes.user.name'), with: long_name
+        choose 'boy-1', allow_label_click: true
+        click_button I18n.t('profiles.edit.submit')
+        expect(page).to have_content(I18n.t('profiles.update.name_length_error', count: 20))
+      end
     end
   end
 end


### PR DESCRIPTION
### 目的
- プロフィール編集のSystemテストを分割し、最大20文字制約を追加
### 変更点
- profile_edit_specへ切り出し、成功/失敗ケース整理、i18nエラー文言追加
- Userモデルに最大文字数２０以内、空文字のバリデーションを追加
### テスト
- System specにて20文字成功・21文字失敗・空失敗・未ログインリダイレクトを確認
- Model specにて 名前が空の場合、２１文字以上の場合のバリデーションエラーを確認

#137
