### PR TITLE
🐛 fix: #150 compose up DB不具合解消

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgres
+    image: postgres:17
     restart: always
     environment:
       TZ: Asia/Tokyo
@@ -36,3 +36,4 @@ volumes:
   bundle_data:
   postgresql_data:
   node_modules:
+


### PR DESCRIPTION
## 概要
対応PR：Issue #150

## 対応内容
- postgres:17にバージョン指定
- <行った修正2>
- <行った修正3>

## 目的
- compose up 時のDB起動不具合の解消。Postgresのタグ未指定で互換性が揺れるのを防ぐため 17 に固定

## 動作確認方法
1. docker compose up
2. localhost 3000にアクセスし、DBエラーが出ないこと

## スクリーンショット / 動作イメージ（あれば）
<画像 or GIF>

## 備考
- <補足事項があれば>