### PR TITLE
Feat/sleep edit

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.6)
       msgpack (~> 1.2)
-    brakeman (7.1.0)
+    brakeman (7.1.1)
       racc
     builder (3.3.0)
     capybara (3.40.0)

--- a/app/controllers/sleep_records_controller.rb
+++ b/app/controllers/sleep_records_controller.rb
@@ -5,13 +5,13 @@ class SleepRecordsController < ApplicationController
 
   def new
     @sleep_record = current_user.sleep_records.build
-    
+
     if params[:date].present?
       date = Date.parse(params[:date])
       @sleep_record.wake_time = Time.zone.local(date.year, date.month, date.day, 6, 0)
       @sleep_record.bed_time = Time.zone.local(date.year, date.month, date.day, 22, 0)
     end
-    
+
     session[:return_to] = request.referer
   end
 
@@ -63,13 +63,13 @@ class SleepRecordsController < ApplicationController
   def create_from_form
     wake_time_param = params[:sleep_record][:wake_time]
     bed_time_param = params[:sleep_record][:bed_time]
-    
+
     attributes = {}
     attributes[:wake_time] = Time.zone.parse(wake_time_param) if wake_time_param.present?
     attributes[:bed_time] = Time.zone.parse(bed_time_param) if bed_time_param.present?
-    
+
     @sleep_record = current_user.sleep_records.build(attributes)
-    
+
     if @sleep_record.save
       return_path = session.delete(:return_to) || authenticated_root_path
       redirect_to return_path, notice: "記録を作成しました"
@@ -92,11 +92,11 @@ class SleepRecordsController < ApplicationController
   def update_sleep_record
     wake_time_param = params[:sleep_record][:wake_time]
     bed_time_param = params[:sleep_record][:bed_time]
-    
+
     attributes = {}
     attributes[:wake_time] = Time.zone.parse(wake_time_param) if wake_time_param.present?
     attributes[:bed_time] = Time.zone.parse(bed_time_param) if bed_time_param.present?
-    
+
     if @sleep_record.update(attributes)
       return_path = session.delete(:return_to) || authenticated_root_path
       redirect_to return_path, notice: "記録を更新しました"

--- a/app/controllers/sleep_records_controller.rb
+++ b/app/controllers/sleep_records_controller.rb
@@ -1,18 +1,46 @@
 class SleepRecordsController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_unwoken_record
+  before_action :set_unwoken_record, only: [ :create ]
+  before_action :set_sleep_record, only: [ :edit, :update ]
+
+  def new
+    @sleep_record = current_user.sleep_records.build
+    
+    if params[:date].present?
+      date = Date.parse(params[:date])
+      @sleep_record.wake_time = Time.zone.local(date.year, date.month, date.day, 6, 0)
+      @sleep_record.bed_time = Time.zone.local(date.year, date.month, date.day, 22, 0)
+    end
+    
+    session[:return_to] = request.referer
+  end
 
   def create
-    return redirect_with_flash(:alert, "すでに未就寝レコードがあります") if @unwoken_record
-    create_wake_record
+    if params[:sleep_record].present?
+      create_from_form
+    else
+      return redirect_with_flash(:alert, "すでに未就寝レコードがあります") if @unwoken_record
+      create_wake_record
+    end
   end
 
   def update
-    return redirect_with_flash(:alert, "未就寝レコードがありません") unless @unwoken_record
-    update_bed_time
+    if params[:record_type] == "bed_time"
+      update_bed_time
+    else
+      update_sleep_record
+    end
+  end
+
+  def edit
+    session[:return_to] = request.referer
   end
 
   private
+
+  def set_sleep_record
+    @sleep_record = current_user.sleep_records.find(params[:id])
+  end
 
   def set_unwoken_record
     @unwoken_record = current_user.sleep_records.unbedded.first
@@ -32,12 +60,53 @@ class SleepRecordsController < ApplicationController
     end
   end
 
+  def create_from_form
+    wake_time_param = params[:sleep_record][:wake_time]
+    bed_time_param = params[:sleep_record][:bed_time]
+    
+    attributes = {}
+    attributes[:wake_time] = Time.zone.parse(wake_time_param) if wake_time_param.present?
+    attributes[:bed_time] = Time.zone.parse(bed_time_param) if bed_time_param.present?
+    
+    @sleep_record = current_user.sleep_records.build(attributes)
+    
+    if @sleep_record.save
+      return_path = session.delete(:return_to) || authenticated_root_path
+      redirect_to return_path, notice: "記録を作成しました"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
   def update_bed_time
-    if @unwoken_record.update(bed_time: Time.current)
+    unwoken_record = current_user.sleep_records.unbedded.first
+    return redirect_with_flash(:alert, "未就寝レコードがありません") unless unwoken_record
+
+    if unwoken_record.update(bed_time: Time.current)
       redirect_with_flash(:notice, "就寝時刻を記録しました")
     else
-      redirect_with_flash(:alert, "就寝時刻の記録に失敗しました: #{@unwoken_record.errors.full_messages.join(', ')}")
+      redirect_with_flash(:alert, "就寝時刻の記録に失敗しました: #{unwoken_record.errors.full_messages.join(', ')}")
     end
+  end
+
+  def update_sleep_record
+    wake_time_param = params[:sleep_record][:wake_time]
+    bed_time_param = params[:sleep_record][:bed_time]
+    
+    attributes = {}
+    attributes[:wake_time] = Time.zone.parse(wake_time_param) if wake_time_param.present?
+    attributes[:bed_time] = Time.zone.parse(bed_time_param) if bed_time_param.present?
+    
+    if @sleep_record.update(attributes)
+      return_path = session.delete(:return_to) || authenticated_root_path
+      redirect_to return_path, notice: "記録を更新しました"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def sleep_record_params
+    params.require(:sleep_record).permit(:wake_time, :bed_time)
   end
 
   def redirect_with_flash(type, message)

--- a/app/models/sleep_record.rb
+++ b/app/models/sleep_record.rb
@@ -3,12 +3,22 @@ class SleepRecord < ApplicationRecord
 
   validates :wake_time, presence: true
   validate :bed_time_after_wake_time
+  validate :times_not_in_future
 
   scope :unbedded, -> { where(bed_time: nil) }
   scope :with_wake_time, -> { where.not(wake_time: nil) }
   scope :finished, -> { where.not(bed_time: nil) }
 
   private
+
+  def times_not_in_future
+    if wake_time.present? && wake_time > Time.current
+      errors.add(:wake_time, "未来の時刻は設定できません")
+    end
+    if bed_time.present? && bed_time > Time.current
+      errors.add(:bed_time, "未来の時刻は設定できません")
+    end
+  end
 
   def bed_time_after_wake_time
     return if wake_time.blank? || bed_time.blank?

--- a/app/services/sleep_record_aggregator.rb
+++ b/app/services/sleep_record_aggregator.rb
@@ -42,7 +42,7 @@ class SleepRecordAggregator
   def build_cumulative(days_range)
     return [] if @records.empty?
     sorted = @records.select { |r| r.wake_time.present? }.sort_by(&:wake_time)
-    
+
     prev_record = if sorted.first
       user = sorted.first.user
       range_start = days_range.first
@@ -53,7 +53,7 @@ class SleepRecordAggregator
         user.sleep_records.where("wake_time >= ? AND wake_time < ?", month_start, sorted.first.wake_time).order(wake_time: :desc).first
       end
     end
-    
+
     all_records = [ prev_record, *sorted ].compact
     records_by_date = @records.group_by { |r| r.wake_time&.to_date }.compact
     days_range.map do |day|

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -51,7 +51,7 @@
 
         <!-- 記録テーブル -->
       <div class="card bg-base-100 border border-base-300">
-        <details class="group [&_summary::-webkit-details-marker]:hidden">
+        <details class="group [&_summary::-webkit-details-marker]:hidden" open>
           <summary class="cursor-pointer p-4 font-bold text-xl bg-base-100 flex justify-between items-center rounded-t-lg">
             <%= t('dashboard.index.this_week_records') %>
             <span class="transition-transform duration-300 group-open:rotate-180">⤵︎</span>
@@ -67,6 +67,7 @@
                   <th class="px-4 py-3 text-sm font-semibold text-base-content/70"><%= t('dashboard.index.daily_sleep_hours') %></th>
                   <th class="px-4 py-3 text-sm font-semibold text-base-content/70"><%= t('dashboard.index.cumulative_wake_hours') %></th>
                   <th class="px-4 py-3 text-sm font-semibold text-base-content/70"><%= t('dashboard.index.cumulative_sleep_hours') %></th>
+                  <th class="px-4 py-3 text-sm font-semibold text-base-content/70">操作</th>
                 </tr>
               </thead>
               <tbody>
@@ -109,6 +110,13 @@
                     <td class="px-4 py-3 text-info text-sm font-semibold">
                       <%= record[:cumulative_sleep_hours] || '-' %>
                     </td>
+                    <td class="px-4 py-3">
+                      <% if record[:id].present? %>
+                        <%= link_to '編集', edit_sleep_record_path(record[:id]), class: "btn btn-xs btn-outline" %>
+                      <% else %>
+                        <%= link_to '追加', new_sleep_record_path(date: record[:day]), class: "btn btn-xs btn-outline btn-primary" %>
+                      <% end %>
+                    </td>
                   </tr>
                 <% end %>
               </tbody>
@@ -143,6 +151,7 @@
               <%= button_to I18n.t('dashboard.index.bed_record'),
                   (@unwoken_record ? sleep_record_path(@unwoken_record) : "#"),
                   method: :patch,
+                  params: { record_type: 'bed_time' },
                   class: "btn btn-secondary btn-lg w-full #{'btn-disabled' if @unwoken_record.nil?}",
                   disabled: @unwoken_record.nil? %>
             </div>

--- a/app/views/history/index.html.erb
+++ b/app/views/history/index.html.erb
@@ -55,7 +55,7 @@
 
     <!-- 記録テーブル -->
     <div class="card bg-base-100 border border-base-300">
-      <details class="group [&_summary::-webkit-details-marker]:hidden">
+      <details class="group [&_summary::-webkit-details-marker]:hidden" open>
         <summary class="cursor-pointer p-4 font-bold text-xl bg-base-100 flex justify-between items-center rounded-t-lg">
           <%= t('history.index.this_month_records') %>
           <span class="transition-transform duration-300 group-open:rotate-180">⤵︎</span>
@@ -71,6 +71,7 @@
                 <th><%= t('history.index.daily_sleep_hours') %></th>
                 <th><%= t('history.index.cumulative_wake_hours') %></th>
                 <th><%= t('history.index.cumulative_sleep_hours') %></th>
+                <th>操作</th>
               </tr>
             </thead>
             <tbody>
@@ -110,6 +111,13 @@
                   </td>
                   <td class="text-info text-sm font-semibold">
                     <%= record[:cumulative_sleep_hours] || '-' %>
+                  </td>
+                  <td>
+                    <% if record[:id].present? %>
+                      <%= link_to '編集', edit_sleep_record_path(record[:id]), class: "btn btn-xs btn-outline" %>
+                    <% else %>
+                      <%= link_to '追加', new_sleep_record_path(date: record[:day]), class: "btn btn-xs btn-outline btn-primary" %>
+                    <% end %>
                   </td>
                 </tr>
               <% end %>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,12 @@
+<% if object.errors.any? %>
+  <div class="alert alert-error mb-4">
+    <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current flex-shrink-0 h-5 w-5" fill="none" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z" />
+    </svg>
+    <ul class="text-sm list-disc list-inside">
+      <% object.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/sleep_records/edit.html.erb
+++ b/app/views/sleep_records/edit.html.erb
@@ -1,0 +1,46 @@
+<% content_for :page_title do %>
+  睡眠記録を編集
+<% end %>
+
+<div class="min-h-screen bg-base-200">
+  <div class="container mx-auto p-6 max-w-2xl">
+    <%= render 'shared/navbar' %>
+
+    <div class="card bg-base-100 shadow-xl mt-6">
+      <div class="card-body">
+        <h2 class="card-title text-2xl mb-6">睡眠記録を編集</h2>
+
+        <%= form_with model: @sleep_record, local: true do |f| %>
+          <%= render 'shared/error_messages', object: @sleep_record %>
+
+          <div class="form-control mb-4">
+            <%= f.label :wake_time, "起床時刻", class: "label" %>
+            <%= f.datetime_local_field :wake_time, 
+                class: "input input-bordered w-full", 
+                value: @sleep_record.wake_time&.strftime("%Y-%m-%dT%H:%M"),
+                max: Time.current.strftime("%Y-%m-%dT%H:%M") %>
+            <label class="label">
+              <span class="label-text-alt text-base-content/60">※未来の時刻は設定できません</span>
+            </label>
+          </div>
+
+          <div class="form-control mb-6">
+            <%= f.label :bed_time, "就寝時刻", class: "label" %>
+            <%= f.datetime_local_field :bed_time, 
+                class: "input input-bordered w-full", 
+                value: @sleep_record.bed_time&.strftime("%Y-%m-%dT%H:%M"),
+                max: Time.current.strftime("%Y-%m-%dT%H:%M") %>
+            <label class="label">
+              <span class="label-text-alt text-base-content/60">※未来の時刻は設定できません</span>
+            </label>
+          </div>
+
+          <div class="flex gap-4">
+            <%= f.submit "更新", class: "btn btn-primary flex-1" %>
+            <%= link_to "キャンセル", session[:return_to] || authenticated_root_path, class: "btn btn-outline flex-1" %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/sleep_records/new.html.erb
+++ b/app/views/sleep_records/new.html.erb
@@ -1,0 +1,45 @@
+<% content_for :page_title do %>
+  睡眠記録を追加
+<% end %>
+
+<div class="min-h-screen bg-base-200">
+  <div class="container mx-auto p-6 max-w-2xl">
+    <%= render 'shared/navbar' %>
+
+    <div class="card bg-base-100 shadow-xl mt-6">
+      <div class="card-body">
+        <h2 class="card-title text-2xl mb-6">睡眠記録を追加</h2>
+
+        <%= form_with model: @sleep_record, local: true do |f| %>
+          <%= render 'shared/error_messages', object: @sleep_record %>
+
+          <div class="form-control mb-4">
+            <%= f.label :wake_time, "起床時刻", class: "label" %>
+            <%= f.datetime_local_field :wake_time, 
+                class: "input input-bordered w-full", 
+                max: Time.current.strftime("%Y-%m-%dT%H:%M"),
+                required: true %>
+            <label class="label">
+              <span class="label-text-alt text-base-content/60">※未来の時刻は設定できません</span>
+            </label>
+          </div>
+
+          <div class="form-control mb-6">
+            <%= f.label :bed_time, "就寝時刻（任意）", class: "label" %>
+            <%= f.datetime_local_field :bed_time, 
+                class: "input input-bordered w-full", 
+                max: Time.current.strftime("%Y-%m-%dT%H:%M") %>
+            <label class="label">
+              <span class="label-text-alt text-base-content/60">※未来の時刻は設定できません</span>
+            </label>
+          </div>
+
+          <div class="flex gap-4">
+            <%= f.submit "作成", class: "btn btn-primary flex-1" %>
+            <%= link_to "キャンセル", session[:return_to] || authenticated_root_path, class: "btn btn-outline flex-1" %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -10,6 +10,8 @@
     <div class="card bg-base-100 border border-base-300 p-8 max-w-lg mx-auto">
       <div class="flex flex-col items-center">
         <%= form_with model: current_user, url: profile_path, method: :patch, local: true do |f| %>
+  <%= render 'shared/error_messages', object: current_user %>
+  
   <div>
     <%= f.label :name, t('profiles.edit.name_label') %>
     <%= f.text_field :name, class: "input input-bordered w-full mb-4" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,5 +19,5 @@ Rails.application.routes.draw do
   end
 
 
-  resources :sleep_records, only: [ :create, :update ]
+  resources :sleep_records, only: [ :new, :create, :update, :edit ]
 end

--- a/spec/factories/sleep_records.rb
+++ b/spec/factories/sleep_records.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :sleep_record do
-    wake_time { Time.current }
-    bed_time { Time.current + 8.hours }
+    wake_time { 1.day.ago.change(hour: 6, min: 0) }
+    bed_time { 1.day.ago.change(hour: 23, min: 0) }
     association :user
 
     trait :unbedded do

--- a/spec/models/sleep_record_spec.rb
+++ b/spec/models/sleep_record_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe SleepRecord, type: :model do
 
     context "bed_timeがwake_timeより前の場合" do
       it "無効である" do
-        record = FactoryBot.build(:sleep_record, wake_time: Time.current, bed_time: Time.current - 1.hour)
+        past_time = 1.day.ago
+        record = FactoryBot.build(:sleep_record, wake_time: past_time, bed_time: past_time - 1.hour)
         expect(record).not_to be_valid
         expect(record.errors[:bed_time]).not_to be_empty
       end
@@ -29,7 +30,8 @@ RSpec.describe SleepRecord, type: :model do
 
     context "bed_timeがwake_timeより後の場合" do
       it "有効である" do
-        record = FactoryBot.build(:sleep_record, wake_time: Time.current, bed_time: Time.current + 1.hour)
+        past_time = 1.day.ago
+        record = FactoryBot.build(:sleep_record, wake_time: past_time, bed_time: past_time + 1.hour)
         expect(record).to be_valid
       end
     end

--- a/spec/requests/sleep_records_spec.rb
+++ b/spec/requests/sleep_records_spec.rb
@@ -17,12 +17,116 @@ RSpec.describe "SleepRecords", type: :request do
   end
 
   describe "PATCH /sleep_records/:id" do
-    it "就寝記録が更新できる" do
-      record = FactoryBot.create(:sleep_record, :unbedded, user: user)
-      patch sleep_record_path(record)
-      record.reload
-      expect(record.bed_time).not_to be_nil
+    context "就寝ボタンからの更新" do
+      it "就寝記録が更新できる" do
+        record = FactoryBot.create(:sleep_record, :unbedded, user: user)
+        patch sleep_record_path(record), params: { record_type: "bed_time" }
+        record.reload
+        expect(record.bed_time).not_to be_nil
+        expect(response).to redirect_to(authenticated_root_path)
+      end
+    end
+
+    context "編集フォームからの更新" do
+      it "起床・就寝時刻を編集できる" do
+        wake_time = 2.days.ago.change(hour: 6, min: 0)
+        bed_time = wake_time + 1.hour
+        record = FactoryBot.create(:sleep_record, user: user, wake_time: wake_time, bed_time: bed_time)
+        
+        new_wake_time = 3.days.ago.change(hour: 7, min: 0)
+        new_bed_time = new_wake_time + 2.hours
+
+        patch sleep_record_path(record), params: {
+          sleep_record: {
+            wake_time: new_wake_time.strftime("%Y-%m-%dT%H:%M"),
+            bed_time: new_bed_time.strftime("%Y-%m-%dT%H:%M")
+          }
+        }
+
+        record.reload
+        expect(record.wake_time).to be_within(1.minute).of(new_wake_time)
+        expect(record.bed_time).to be_within(1.minute).of(new_bed_time)
+        expect(response).to redirect_to(authenticated_root_path)
+      end
+
+      it "未来の時刻は保存できない" do
+        wake_time = 2.days.ago.change(hour: 6, min: 0)
+        bed_time = wake_time + 1.hour
+        record = FactoryBot.create(:sleep_record, user: user, wake_time: wake_time, bed_time: bed_time)
+        
+        future_time = 1.day.from_now
+
+        patch sleep_record_path(record), params: {
+          sleep_record: {
+            wake_time: future_time.strftime("%Y-%m-%dT%H:%M"),
+            bed_time: record.bed_time.strftime("%Y-%m-%dT%H:%M")
+          }
+        }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe "GET /sleep_records/new" do
+    it "新規作成画面が表示できる" do
+      get new_sleep_record_path
+      expect(response).to have_http_status(:success)
+    end
+
+    it "日付パラメータがあれば初期値として設定される" do
+      date = "2025-11-01"
+      get new_sleep_record_path(date: date)
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include("2025-11-01T06:00")
+      expect(response.body).to include("2025-11-01T22:00")
+    end
+  end
+
+  describe "GET /sleep_records/:id/edit" do
+    it "編集画面が表示できる" do
+      wake_time = 2.days.ago.change(hour: 6, min: 0)
+      bed_time = wake_time + 1.hour
+      record = FactoryBot.create(:sleep_record, user: user, wake_time: wake_time, bed_time: bed_time)
+      
+      get edit_sleep_record_path(record)
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "POST /sleep_records (フォームから)" do
+    it "過去の記録を新規作成できる" do
+      past_wake_time = 2.days.ago.change(hour: 6, min: 0)
+      past_bed_time = past_wake_time + 1.hour
+
+      expect {
+        post sleep_records_path, params: {
+          sleep_record: {
+            wake_time: past_wake_time.strftime("%Y-%m-%dT%H:%M"),
+            bed_time: past_bed_time.strftime("%Y-%m-%dT%H:%M")
+          }
+        }
+      }.to change { SleepRecord.count }.by(1)
+
+      created_record = SleepRecord.last
+      expect(created_record.wake_time).to be_within(1.minute).of(past_wake_time)
+      expect(created_record.bed_time).to be_within(1.minute).of(past_bed_time)
       expect(response).to redirect_to(authenticated_root_path)
+    end
+
+    it "未来の時刻は保存できない" do
+      future_time = 1.day.from_now
+
+      expect {
+        post sleep_records_path, params: {
+          sleep_record: {
+            wake_time: future_time.strftime("%Y-%m-%dT%H:%M"),
+            bed_time: (future_time + 1.hour).strftime("%Y-%m-%dT%H:%M")
+          }
+        }
+      }.not_to change { SleepRecord.count }
+
+      expect(response).to have_http_status(:unprocessable_entity)
     end
   end
 end

--- a/spec/requests/sleep_records_spec.rb
+++ b/spec/requests/sleep_records_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "SleepRecords", type: :request do
         wake_time = 2.days.ago.change(hour: 6, min: 0)
         bed_time = wake_time + 1.hour
         record = FactoryBot.create(:sleep_record, user: user, wake_time: wake_time, bed_time: bed_time)
-        
+
         new_wake_time = 3.days.ago.change(hour: 7, min: 0)
         new_bed_time = new_wake_time + 2.hours
 
@@ -53,7 +53,7 @@ RSpec.describe "SleepRecords", type: :request do
         wake_time = 2.days.ago.change(hour: 6, min: 0)
         bed_time = wake_time + 1.hour
         record = FactoryBot.create(:sleep_record, user: user, wake_time: wake_time, bed_time: bed_time)
-        
+
         future_time = 1.day.from_now
 
         patch sleep_record_path(record), params: {
@@ -88,7 +88,7 @@ RSpec.describe "SleepRecords", type: :request do
       wake_time = 2.days.ago.change(hour: 6, min: 0)
       bed_time = wake_time + 1.hour
       record = FactoryBot.create(:sleep_record, user: user, wake_time: wake_time, bed_time: bed_time)
-      
+
       get edit_sleep_record_path(record)
       expect(response).to have_http_status(:success)
     end


### PR DESCRIPTION
## 概要
睡眠記録の編集・新規作成機能を追加

対応PR：Issue #25 

## 対応内容
- 既存の睡眠記録（起床時刻・就寝時刻）を編集できる機能を追加
- 過去の日付の記録を新規作成できる機能を追加
- エラーメッセージ表示の共通化
- 未来の時刻への編集を制限するバリデーションを追加
- 累計値を月ごとにリセットする仕様に変更
- 1日複数レコード（昼寝など）に対応

## 目的
- 記録の誤入力を修正できるようにする
- 記録忘れに後から対応できるようにする
- ユーザビリティの向上（過去の記録も含めて管理できる）
- データの整合性を保つ（月次統計として自然な累計表示）

## 変更ファイル
### 新規作成
- `app/views/shared/_error_messages.html.erb` - エラーメッセージ共通パーシャル
- `app/views/sleep_records/edit.html.erb` - 編集画面
- `app/views/sleep_records/new.html.erb` - 新規作成画面
- `spec/requests/sleep_records_spec.rb` - テスト追加

### 修正
- `config/routes.rb` - edit/newルート追加
- `app/controllers/sleep_records_controller.rb` - edit/new/updateアクション追加
- `app/models/sleep_record.rb` - 未来時刻制限バリデーション追加
- `app/services/sleep_record_aggregator.rb` - 月次リセット・複数レコード対応
- `app/views/dashboard/index.html.erb` - 編集・追加ボタン追加
- `app/views/history/index.html.erb` - 編集・追加ボタン追加
- `app/views/users/edit.html.erb` - エラー表示を共通パーシャル化

## 動作確認方法

### 編集機能
1. ダッシュボードまたは履歴ページにアクセス
2. 既存の記録がある日の「編集」ボタンをクリック
3. 起床・就寝時刻を変更して「更新」ボタンをクリック
4. 元のページに戻り、変更が反映されていることを確認

### 新規作成機能
1. ダッシュボードまたは履歴ページにアクセス
2. 記録がない日の「追加」ボタンをクリック
3. 起床・就寝時刻が自動入力されていることを確認（朝6時・夜22時）
4. 必要に応じて時刻を調整して「作成」ボタンをクリック
5. 元のページに戻り、記録が追加されていることを確認

### バリデーション確認
1. 編集または新規作成画面で未来の時刻を入力
2. 「更新」または「作成」ボタンをクリック
3. エラーメッセージ「未来の時刻は設定できません」が表示されることを確認

### 月次リセット確認
1. 履歴ページで任意の月を表示
2. 累計値がその月の初日から計算されていることを確認
3. 過去の記録を追加して、累計が正しく再計算されることを確認

## テスト
```bash
bundle exec rspec [sleep_records_spec.rb](http://_vscodecontentref_/0)
```

全9テストが成功することを確認済み

