### PR TITLE
Feat/responsive index

### DIFF
--- a/app/javascript/charts/sleep_chart.js
+++ b/app/javascript/charts/sleep_chart.js
@@ -17,8 +17,10 @@ document.addEventListener("turbo:load", () => {
         chart: {
           backgroundColor: "transparent",
           type: "area",
-          zoomType: "x"
+          zoomType: "x",
+          scrollablePlotArea: { minWidth: 400, scrollPositionX: 1 },
         },
+        accessibility: { enabled: false },
         colors: ["rgb(72, 125, 0)"],
         tooltip: {
           formatter: function() {

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -29,13 +29,15 @@
               <%= button_to I18n.t('dashboard.index.wake_record'), sleep_records_path,
                   method: :post,
                   class: "btn btn-primary btn-lg w-full #{'btn-disabled' if @unwoken_record.present?}",
-                  disabled: @unwoken_record.present? %>
+                  disabled: @unwoken_record.present?,
+                  data: { test: 'mobile-wake-button' } %>
               <%= button_to I18n.t('dashboard.index.bed_record'),
                   (@unwoken_record ? sleep_record_path(@unwoken_record) : "#"),
                   method: :patch,
                   params: { record_type: 'bed_time' },
                   class: "btn btn-secondary btn-lg w-full #{'btn-disabled' if @unwoken_record.nil?}",
-                  disabled: @unwoken_record.nil? %>
+                  disabled: @unwoken_record.nil?,
+                  data: { test: 'mobile-bed-button' } %>
             </div>
           </div>
         </div>
@@ -246,13 +248,15 @@
               <%= button_to I18n.t('dashboard.index.wake_record'), sleep_records_path,
                   method: :post,
                   class: "btn btn-primary btn-lg w-full #{'btn-disabled' if @unwoken_record.present?}",
-                  disabled: @unwoken_record.present? %>
+                  disabled: @unwoken_record.present?,
+                  data: { test: 'desktop-wake-button' } %>
               <%= button_to I18n.t('dashboard.index.bed_record'),
                   (@unwoken_record ? sleep_record_path(@unwoken_record) : "#"),
                   method: :patch,
                   params: { record_type: 'bed_time' },
                   class: "btn btn-secondary btn-lg w-full #{'btn-disabled' if @unwoken_record.nil?}",
-                  disabled: @unwoken_record.nil? %>
+                  disabled: @unwoken_record.nil?,
+                  data: { test: 'desktop-bed-button' } %>
             </div>
           </div>
         </div>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -5,9 +5,9 @@
   <div class="container mx-auto p-6">
     <%= render 'shared/navbar' %>
 
-    <div class="flex flex-col lg:flex-row gap-6 mb-8">
+    <div class="flex flex-col lg:flex-row gap-3 sm:gap-4 lg:gap-6 mb-6 sm:mb-8">
       <!-- 左カラム -->
-      <div class="w-full lg:flex-[7] flex flex-col gap-6">
+      <div class="w-full lg:flex-[7] flex flex-col gap-3 sm:gap-4 lg:gap-6">
         <!-- グラフ -->
         <div class="card bg-base-100 border border-base-300">
           <div class="card-body p-4">
@@ -17,132 +17,231 @@
             </div>
             <div id="sleep-chart"
               data-series='<%= @series.to_json.html_safe %>'
-              style="height: 350px;">
+              class="h-[250px] sm:h-[300px] lg:h-[350px]">
             </div>
           </div>
         </div>
-        <!-- 統計 -->
-        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
-          <div class="card bg-base-100 border border-base-300 text-center p-4">
-            <div class="text-xs text-base-content/70 mb-2"><%= t('dashboard.index.weekly_average_wake_hours') %></div>
-            <div class="text-2xl font-bold text-success">
-              <%= @weekly_average_wake_hours ? sprintf("%.2f", @weekly_average_wake_hours) : '-' %>h
-            </div>
-          </div>
-          <div class="card bg-base-100 border border-base-300 text-center p-4">
-            <div class="text-xs text-base-content/70 mb-2"><%= t('dashboard.index.weekly_average_sleep_hours') %></div>
-            <div class="text-2xl font-bold text-info">
-              <%= @weekly_average_sleep_hours ? sprintf("%.2f", @weekly_average_sleep_hours) : '-' %>h
-            </div>
-          </div>
-          <div class="card bg-base-100 border border-base-300 text-center p-4">
-            <div class="text-xs text-base-content/70 mb-2"><%= t('dashboard.index.weekly_average_wake_time') %></div>
-            <div class="text-2xl font-bold text-primary">
-              <%= @weekly_average_wake_time || "--:--" %>
-            </div>
-          </div>
-          <div class="card bg-base-100 border border-base-300 text-center p-4">
-            <div class="text-xs text-base-content/70 mb-2"><%= t('dashboard.index.weekly_average_bed_time') %></div>
-            <div class="text-2xl font-bold text-secondary">
-              <%= @weekly_average_bed_time || "--:--" %>
+
+        <!-- 記録カード（モバイル） -->
+        <div class="lg:hidden card bg-base-100 border border-base-300">
+          <div class="card-body p-4">
+            <div class="space-y-3">
+              <%= button_to I18n.t('dashboard.index.wake_record'), sleep_records_path,
+                  method: :post,
+                  class: "btn btn-primary btn-lg w-full #{'btn-disabled' if @unwoken_record.present?}",
+                  disabled: @unwoken_record.present? %>
+              <%= button_to I18n.t('dashboard.index.bed_record'),
+                  (@unwoken_record ? sleep_record_path(@unwoken_record) : "#"),
+                  method: :patch,
+                  params: { record_type: 'bed_time' },
+                  class: "btn btn-secondary btn-lg w-full #{'btn-disabled' if @unwoken_record.nil?}",
+                  disabled: @unwoken_record.nil? %>
             </div>
           </div>
         </div>
 
         <!-- 記録テーブル -->
-      <div class="card bg-base-100 border border-base-300">
-        <details class="group [&_summary::-webkit-details-marker]:hidden" open>
-          <summary class="cursor-pointer p-4 font-bold text-xl bg-base-100 flex justify-between items-center rounded-t-lg">
-            <%= t('dashboard.index.this_week_records') %>
-            <span class="transition-transform duration-300 group-open:rotate-180">⤵︎</span>
-          </summary>
-          <div class="overflow-x-auto p-4">
-            <table class="table table-zebra w-full border-t border-base-300">
-              <thead class="bg-base-200">
-                <tr>
-                  <th class="px-4 py-3 text-sm font-semibold text-base-content/70"><%= t('dashboard.index.date') %></th>
-                  <th class="px-4 py-3 text-sm font-semibold text-base-content/70"><%= t('dashboard.index.wake_time') %></th>
-                  <th class="px-4 py-3 text-sm font-semibold text-base-content/70"><%= t('dashboard.index.bed_time') %></th>
-                  <th class="px-4 py-3 text-sm font-semibold text-base-content/70"><%= t('dashboard.index.daily_wake_hours') %></th>
-                  <th class="px-4 py-3 text-sm font-semibold text-base-content/70"><%= t('dashboard.index.daily_sleep_hours') %></th>
-                  <th class="px-4 py-3 text-sm font-semibold text-base-content/70"><%= t('dashboard.index.cumulative_wake_hours') %></th>
-                  <th class="px-4 py-3 text-sm font-semibold text-base-content/70"><%= t('dashboard.index.cumulative_sleep_hours') %></th>
-                  <th class="px-4 py-3 text-sm font-semibold text-base-content/70">操作</th>
-                </tr>
-              </thead>
-              <tbody>
+        <div class="card bg-base-100 border border-base-300">
+          <details class="group [&_summary::-webkit-details-marker]:hidden">
+            <summary class="cursor-pointer p-4 font-bold text-xl bg-base-100 flex justify-between items-center rounded-t-lg">
+              <%= t('dashboard.index.this_week_records') %>
+              <span class="transition-transform duration-300 group-open:rotate-180">⤵︎</span>
+            </summary>
+            <div class="p-4">
+              <!-- モバイル用カード表示 -->
+              <div class="md:hidden space-y-2">
                 <% @weekly_records.each_with_index do |record, idx| %>
-                  <tr class="hover">
-                    <td class="px-4 py-3">
-                      <%= record[:day].is_a?(Date) ? record[:day].strftime("%m-%d (%a)") : '--' %>
-                    </td>
-                    <td class="px-4 py-3">
-                      <% if record[:wake_times].present? %>
-                        <% record[:wake_times].each do |time| %>
-                          <span class="badge badge-success badge-sm mb-1">
-                            <%= Time.parse(time).strftime("%m/%d_%H:%M") %>
-                          </span>
-                        <% end %>
-                      <% else %>
-                        <span class="text-base-content/40">-</span>
-                      <% end %>
-                    </td>
-                    <td class="px-4 py-3">
-                      <% if record[:bed_times].present? %>
-                        <% record[:bed_times].each do |time| %>
-                          <span class="badge badge-secondary badge-sm mb-1">
-                            <%= Time.parse(time).strftime("%m/%d_%H:%M") %>
-                          </span>
-                        <% end %>
-                      <% else %>
-                        <span class="text-base-content/40">-</span>
-                      <% end %>
-                    </td>
-                    <td class="px-4 py-3 text-accent font-semibold">
-                      <%= record[:daily_wake_hours] ? sprintf("%.2f", record[:daily_wake_hours]) : '-' %>
-                    </td>
-                    <td class="px-4 py-3 text-info font-semibold">
-                      <%= record[:daily_sleep_hours] ? sprintf("%.2f", record[:daily_sleep_hours]) : '-' %>
-                    </td>
-                    <td class="px-4 py-3 text-accent text-sm font-semibold">
-                      <%= record[:cumulative_wake_hours] || '-' %>
-                    </td>
-                    <td class="px-4 py-3 text-info text-sm font-semibold">
-                      <%= record[:cumulative_sleep_hours] || '-' %>
-                    </td>
-                    <td class="px-4 py-3">
-                      <% if record[:id].present? %>
-                        <%= link_to '編集', edit_sleep_record_path(record[:id]), class: "btn btn-xs btn-outline" %>
-                      <% else %>
-                        <%= link_to '追加', new_sleep_record_path(date: record[:day]), class: "btn btn-xs btn-outline btn-primary" %>
-                      <% end %>
-                    </td>
-                  </tr>
-                <% end %>
-              </tbody>
-            </table>
-          </div>
-        </details>
-      </div>
+                  <div class="card bg-base-100 border border-base-300 shadow-sm">
+                    <details class="group">
+                      <summary class="cursor-pointer p-3 flex justify-between items-center list-none">
+                        <div class="flex-1">
+                          <div class="flex items-center gap-3 mb-1">
+                            <h4 class="font-bold text-sm">
+                              <%= record[:day].is_a?(Date) ? record[:day].strftime("%m-%d (%a)") : '--' %>
+                            </h4>
+                            <% if record[:id].present? %>
+                              <%= link_to '編集', edit_sleep_record_path(record[:id]), class: "btn btn-xs btn-outline", onclick: "event.stopPropagation()" %>
+                            <% else %>
+                              <%= link_to '追加', new_sleep_record_path(date: record[:day]), class: "btn btn-xs btn-outline btn-primary", onclick: "event.stopPropagation()" %>
+                            <% end %>
+                          </div>
+                          <div class="text-xs text-base-content/70 flex gap-4">
+                            <span class="flex items-center gap-1">
+                              <i class="ph-fill ph-sun text-warning"></i>
+                              <% if record[:wake_times].present? %>
+                                <%= Time.parse(record[:wake_times].first).strftime("%H:%M") %>
+                              <% else %>
+                                -
+                              <% end %>
+                            </span>
+                            <span class="flex items-center gap-1">
+                              <i class="ph-fill ph-moon text-info"></i>
+                              <% if record[:bed_times].present? %>
+                                <%= Time.parse(record[:bed_times].last).strftime("%H:%M") %>
+                              <% else %>
+                                -
+                              <% end %>
+                            </span>
+                          </div>
+                        </div>
+                        <span class="transition-transform duration-300 group-open:rotate-180 text-base-content/50">▼</span>
+                      </summary>
 
+                      <div class="px-3 pb-3 pt-2 border-t border-base-300">
+                        <div class="grid grid-cols-2 gap-3 text-sm">
+                          <div>
+                            <div class="text-xs text-base-content/70 mb-1"><%= t('dashboard.index.wake_time') %></div>
+                            <% if record[:wake_times].present? %>
+                              <% record[:wake_times].each do |time| %>
+                                <span class="badge badge-success badge-sm mb-1 text-xs">
+                                  <%= Time.parse(time).strftime("%H:%M") %>
+                                </span>
+                              <% end %>
+                            <% else %>
+                              <span class="text-base-content/40">-</span>
+                            <% end %>
+                          </div>
+
+                          <div>
+                            <div class="text-xs text-base-content/70 mb-1"><%= t('dashboard.index.bed_time') %></div>
+                            <% if record[:bed_times].present? %>
+                              <% record[:bed_times].each do |time| %>
+                                <span class="badge badge-secondary badge-sm mb-1 text-xs">
+                                  <%= Time.parse(time).strftime("%H:%M") %>
+                                </span>
+                              <% end %>
+                            <% else %>
+                              <span class="text-base-content/40">-</span>
+                            <% end %>
+                          </div>
+
+                          <div>
+                            <div class="text-xs text-base-content/70 mb-1"><%= t('dashboard.index.cumulative_wake_hours') %></div>
+                            <div class="text-accent text-sm font-semibold">
+                              <%= record[:cumulative_wake_hours] || '-' %>
+                            </div>
+                          </div>
+
+                          <div>
+                            <div class="text-xs text-base-content/70 mb-1"><%= t('dashboard.index.cumulative_sleep_hours') %></div>
+                            <div class="text-info text-sm font-semibold">
+                              <%= record[:cumulative_sleep_hours] || '-' %>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </details>
+                  </div>
+                <% end %>
+              </div>
+
+              <!-- デスクトップ用テーブル表示 -->
+              <div class="hidden md:block overflow-x-auto">
+                <table class="table table-zebra w-full border-t border-base-300 text-sm">
+                  <thead class="bg-base-200">
+                    <tr>
+                      <th class="px-4 py-3 text-sm font-semibold text-base-content/70"><%= t('dashboard.index.date') %></th>
+                      <th class="px-4 py-3 text-sm font-semibold text-base-content/70"><%= t('dashboard.index.wake_time') %></th>
+                      <th class="px-4 py-3 text-sm font-semibold text-base-content/70"><%= t('dashboard.index.bed_time') %></th>
+                      <th class="px-4 py-3 text-sm font-semibold text-base-content/70"><%= t('dashboard.index.daily_wake_hours') %></th>
+                      <th class="px-4 py-3 text-sm font-semibold text-base-content/70"><%= t('dashboard.index.daily_sleep_hours') %></th>
+                      <th class="px-4 py-3 text-sm font-semibold text-base-content/70"><%= t('dashboard.index.cumulative_wake_hours') %></th>
+                      <th class="px-4 py-3 text-sm font-semibold text-base-content/70"><%= t('dashboard.index.cumulative_sleep_hours') %></th>
+                      <th class="px-4 py-3 text-sm font-semibold text-base-content/70">操作</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <% @weekly_records.each_with_index do |record, idx| %>
+                      <tr class="hover">
+                        <td class="px-4 py-3 whitespace-nowrap">
+                          <%= record[:day].is_a?(Date) ? record[:day].strftime("%m-%d (%a)") : '--' %>
+                        </td>
+                        <td class="px-4 py-3">
+                          <% if record[:wake_times].present? %>
+                            <% record[:wake_times].each do |time| %>
+                              <span class="badge badge-success badge-sm mb-1 text-xs">
+                                <%= Time.parse(time).strftime("%m/%d_%H:%M") %>
+                              </span>
+                            <% end %>
+                          <% else %>
+                            <span class="text-base-content/40">-</span>
+                          <% end %>
+                        </td>
+                        <td class="px-4 py-3">
+                          <% if record[:bed_times].present? %>
+                            <% record[:bed_times].each do |time| %>
+                              <span class="badge badge-secondary badge-sm mb-1 text-xs">
+                                <%= Time.parse(time).strftime("%m/%d_%H:%M") %>
+                              </span>
+                            <% end %>
+                          <% else %>
+                            <span class="text-base-content/40">-</span>
+                          <% end %>
+                        </td>
+                        <td class="px-4 py-3 text-accent font-semibold">
+                          <%= record[:daily_wake_hours] ? sprintf("%.2f", record[:daily_wake_hours]) : '-' %>
+                        </td>
+                        <td class="px-4 py-3 text-info font-semibold">
+                          <%= record[:daily_sleep_hours] ? sprintf("%.2f", record[:daily_sleep_hours]) : '-' %>
+                        </td>
+                        <td class="px-4 py-3 text-accent text-sm font-semibold">
+                          <%= record[:cumulative_wake_hours] || '-' %>
+                        </td>
+                        <td class="px-4 py-3 text-info text-sm font-semibold">
+                          <%= record[:cumulative_sleep_hours] || '-' %>
+                        </td>
+                        <td class="px-4 py-3">
+                          <% if record[:id].present? %>
+                            <%= link_to '編集', edit_sleep_record_path(record[:id]), class: "btn btn-xs btn-outline whitespace-nowrap" %>
+                          <% else %>
+                            <%= link_to '追加', new_sleep_record_path(date: record[:day]), class: "btn btn-xs btn-outline btn-primary whitespace-nowrap" %>
+                          <% end %>
+                        </td>
+                      </tr>
+                    <% end %>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </details>
+        </div>
+
+        <!-- 統計 -->
+        <div class="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4 lg:gap-6">
+          <div class="card bg-base-100 border border-base-300 text-center p-3 sm:p-4">
+            <div class="text-[10px] sm:text-xs text-base-content/70 mb-1 sm:mb-2 leading-tight"><%= t('dashboard.index.weekly_average_wake_hours') %></div>
+            <div class="text-lg sm:text-xl lg:text-2xl font-bold text-success">
+              <%= @weekly_average_wake_hours ? sprintf("%.2f", @weekly_average_wake_hours) : '-' %>h
+            </div>
+          </div>
+          <div class="card bg-base-100 border border-base-300 text-center p-3 sm:p-4">
+            <div class="text-[10px] sm:text-xs text-base-content/70 mb-1 sm:mb-2 leading-tight"><%= t('dashboard.index.weekly_average_sleep_hours') %></div>
+            <div class="text-lg sm:text-xl lg:text-2xl font-bold text-info">
+              <%= @weekly_average_sleep_hours ? sprintf("%.2f", @weekly_average_sleep_hours) : '-' %>h
+            </div>
+          </div>
+          <div class="card bg-base-100 border border-base-300 text-center p-3 sm:p-4">
+            <div class="text-[10px] sm:text-xs text-base-content/70 mb-1 sm:mb-2 leading-tight"><%= t('dashboard.index.weekly_average_wake_time') %></div>
+            <div class="text-lg sm:text-xl lg:text-2xl font-bold text-primary">
+              <%= @weekly_average_wake_time || "--:--" %>
+            </div>
+          </div>
+          <div class="card bg-base-100 border border-base-300 text-center p-3 sm:p-4">
+            <div class="text-[10px] sm:text-xs text-base-content/70 mb-1 sm:mb-2 leading-tight"><%= t('dashboard.index.weekly_average_bed_time') %></div>
+            <div class="text-lg sm:text-xl lg:text-2xl font-bold text-secondary">
+              <%= @weekly_average_bed_time || "--:--" %>
+            </div>
+          </div>
+        </div>
 
       </div>
 
       <!-- 右カラム -->
-      <div class="w-full lg:flex-[3] flex flex-col gap-6">
+      <div class="hidden lg:flex w-full lg:flex-[3] flex-col gap-3 sm:gap-4 lg:gap-6">
 
         <!-- 記録カード -->
-        <div class="h-[240px] card bg-base-100 border border-base-300">
-          <div class="card-body p-4 flex flex-col justify-between">
-            <div class="text-center p-3 bg-base-200">
-              <div class="text-2xl font-mono font-bold text-base-content">
-                <%= Time.current.strftime("%H:%M") %>
-              </div>
-              <div class="text-xs text-base-content/70">
-                <%= Time.current.strftime("%Y/%m/%d") %>
-              </div>
-            </div>
-
+        <div class="card bg-base-100 border border-base-300">
+          <div class="card-body p-4">
             <div class="space-y-3">
               <%= button_to I18n.t('dashboard.index.wake_record'), sleep_records_path,
                   method: :post,

--- a/app/views/history/index.html.erb
+++ b/app/views/history/index.html.erb
@@ -6,125 +6,224 @@
     <%= render 'shared/navbar' %>
 
     <!-- 活動グラフ -->
-    <div class="card bg-base-100 border border-base-300 mb-6">
+    <div class="card bg-base-100 border border-base-300 mb-3 sm:mb-4 lg:mb-6">
       <div class="card-body p-4">
         <div class="flex items-center justify-between mb-4">
           <h3 class="text-2xl font-bold"><%= t('history.index.activity_graph') %></h3>
-          <%= form_with url: history_path, method: :get, local: true, class: "flex gap-2 items-center" do %>
-            <%= select_tag :year, options_for_select((2025..Date.current.year).to_a.reverse, @selected_year), class: "select select-bordered select-sm w-20" %>
+          <%= form_with url: history_path, method: :get, local: true, class: "flex gap-2 items-center", id: "history-form" do %>
+            <%= select_tag :year,
+                options_for_select((2025..Date.current.year).to_a.reverse, @selected_year),
+                class: "select select-bordered select-sm w-20",
+                onchange: "this.form.submit();" %>
             <label for="year" class="text-xs"><%= t('history.index.year') %></label>
-            <%= select_tag :month, options_for_select((1..12).to_a, @selected_month), class: "select select-bordered select-sm w-16" %>
+
+            <%= select_tag :month,
+                options_for_select((1..12).to_a, @selected_month),
+                class: "select select-bordered select-sm w-16",
+                onchange: "this.form.submit();" %>
             <label for="month" class="text-xs"><%= t('history.index.month') %></label>
-            <%= submit_tag t('history.index.show'), class: "btn btn-primary btn-sm" %>
           <% end %>
         </div>
-        <div id="sleep-chart"
-             data-series='<%= @series.to_json.html_safe %>'
-             style="height: 350px;">
+        <div class="overflow-x-auto">
+          <div id="sleep-chart"
+              data-series='<%= @series.to_json.html_safe %>'
+              class="min-w-[1200px] h-[250px] sm:h-[300px] lg:h-[350px]">
+          </div>
         </div>
-      </div>
-    </div>
 
-    <!-- 月間統計 -->
-    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 mb-6">
-      <div class="card bg-base-100 border border-base-300 text-center p-4">
-        <div class="text-xs text-base-content/70 mb-2"><%= t('history.index.month_average_wake_hours') %></div>
-        <div class="text-2xl font-bold text-success">
-          <%= @month_average_wake_hours ? sprintf("%.2f", @month_average_wake_hours) : '-' %>h
-        </div>
-      </div>
-      <div class="card bg-base-100 border border-base-300 text-center p-4">
-        <div class="text-xs text-base-content/70 mb-2"><%= t('history.index.month_average_sleep_hours') %></div>
-        <div class="text-2xl font-bold text-info">
-          <%= @month_average_sleep_hours ? sprintf("%.2f", @month_average_sleep_hours) : '-' %>h
-        </div>
-      </div>
-      <div class="card bg-base-100 border border-base-300 text-center p-4">
-        <div class="text-xs text-base-content/70 mb-2"><%= t('history.index.month_average_wake_time') %></div>
-        <div class="text-2xl font-bold text-success">
-          <%= @month_average_wake_time || '-' %>
-        </div>
-      </div>
-      <div class="card bg-base-100 border border-base-300 text-center p-4">
-        <div class="text-xs text-base-content/70 mb-2"><%= t('history.index.month_average_bed_time') %></div>
-        <div class="text-2xl font-bold text-info">
-          <%= @month_average_bed_time || '-' %>
-        </div>
       </div>
     </div>
 
     <!-- 記録テーブル -->
-    <div class="card bg-base-100 border border-base-300">
-      <details class="group [&_summary::-webkit-details-marker]:hidden" open>
+    <div class="card bg-base-100 border border-base-300 mb-3 sm:mb-4 lg:mb-6">
+      <details class="group [&_summary::-webkit-details-marker]:hidden">
         <summary class="cursor-pointer p-4 font-bold text-xl bg-base-100 flex justify-between items-center rounded-t-lg">
           <%= t('history.index.this_month_records') %>
           <span class="transition-transform duration-300 group-open:rotate-180">⤵︎</span>
         </summary>
-        <div class="overflow-x-auto p-4">
-          <table class="table table-zebra w-full border-t border-base-300">
-            <thead class="bg-base-200">
-              <tr>
-                <th><%= t('history.index.date') %></th>
-                <th><%= t('history.index.wake_time') %></th>
-                <th><%= t('history.index.bed_time') %></th>
-                <th><%= t('history.index.daily_wake_hours') %></th>
-                <th><%= t('history.index.daily_sleep_hours') %></th>
-                <th><%= t('history.index.cumulative_wake_hours') %></th>
-                <th><%= t('history.index.cumulative_sleep_hours') %></th>
-                <th>操作</th>
-              </tr>
-            </thead>
-            <tbody>
-              <% @monthly_records.each do |record| %>
-                <tr class="hover">
-                  <td><%= record[:day].is_a?(Date) ? record[:day].strftime("%m-%d (%a)") : '--' %></td>
-                  <td>
-                    <% if record[:wake_times].present? %>
-                      <% record[:wake_times].each do |time| %>
-                        <span class="badge badge-success badge-sm mb-1">
-                          <%= Time.parse(time).strftime("%m/%d_%H:%M") %>
+        <div class="p-4">
+          <!-- モバイル用カード表示 -->
+          <div class="md:hidden space-y-2">
+            <% @monthly_records.each do |record| %>
+              <div class="card bg-base-100 border border-base-300 shadow-sm">
+                <details class="group">
+                  <summary class="cursor-pointer p-3 flex justify-between items-center list-none">
+                    <div class="flex-1">
+                      <div class="flex items-center gap-3 mb-1">
+                        <h4 class="font-bold text-sm">
+                          <%= record[:day].is_a?(Date) ? record[:day].strftime("%m-%d (%a)") : '--' %>
+                        </h4>
+                        <% if record[:id].present? %>
+                          <%= link_to '編集', edit_sleep_record_path(record[:id]), class: "btn btn-xs btn-outline", onclick: "event.stopPropagation()" %>
+                        <% else %>
+                          <%= link_to '追加', new_sleep_record_path(date: record[:day]), class: "btn btn-xs btn-outline btn-primary", onclick: "event.stopPropagation()" %>
+                        <% end %>
+                      </div>
+                      <div class="text-xs text-base-content/70 flex gap-4">
+                        <span class="flex items-center gap-1">
+                          <i class="ph-fill ph-sun text-warning"></i>
+                          <% if record[:wake_times].present? %>
+                            <%= Time.parse(record[:wake_times].first).strftime("%H:%M") %>
+                          <% else %>
+                            -
+                          <% end %>
                         </span>
-                      <% end %>
-                    <% else %>
-                      <span class="text-base-content/40">-</span>
-                    <% end %>
-                  </td>
-                  <td>
-                    <% if record[:bed_times].present? %>
-                      <% record[:bed_times].each do |time| %>
-                        <span class="badge badge-secondary badge-sm mb-1">
-                          <%= Time.parse(time).strftime("%m/%d_%H:%M") %>
+                        <span class="flex items-center gap-1">
+                          <i class="ph-fill ph-moon text-info"></i>
+                          <% if record[:bed_times].present? %>
+                            <%= Time.parse(record[:bed_times].last).strftime("%H:%M") %>
+                          <% else %>
+                            -
+                          <% end %>
                         </span>
-                      <% end %>
-                    <% else %>
-                      <span class="text-base-content/40">-</span>
-                    <% end %>
-                  </td>
-                  <td class="text-accent font-semibold">
-                    <%= record[:daily_wake_hours] ? sprintf("%.2f", record[:daily_wake_hours]) : '-' %>
-                  </td>
-                  <td class="text-info font-semibold">
-                    <%= record[:daily_sleep_hours] ? sprintf("%.2f", record[:daily_sleep_hours]) : '-' %>
-                  </td>
-                  <td class="text-accent text-sm font-semibold">
-                    <%= record[:cumulative_wake_hours] || '-' %>
-                  </td>
-                  <td class="text-info text-sm font-semibold">
-                    <%= record[:cumulative_sleep_hours] || '-' %>
-                  </td>
-                  <td>
-                    <% if record[:id].present? %>
-                      <%= link_to '編集', edit_sleep_record_path(record[:id]), class: "btn btn-xs btn-outline" %>
-                    <% else %>
-                      <%= link_to '追加', new_sleep_record_path(date: record[:day]), class: "btn btn-xs btn-outline btn-primary" %>
-                    <% end %>
-                  </td>
+                      </div>
+                    </div>
+                    <span class="transition-transform duration-300 group-open:rotate-180 text-base-content/50">▼</span>
+                  </summary>
+
+                  <div class="px-3 pb-3 pt-2 border-t border-base-300">
+                    <div class="grid grid-cols-2 gap-3 text-sm">
+                      <div>
+                        <div class="text-xs text-base-content/70 mb-1"><%= t('history.index.wake_time') %></div>
+                        <% if record[:wake_times].present? %>
+                          <% record[:wake_times].each do |time| %>
+                            <span class="badge badge-success badge-sm mb-1 text-xs">
+                              <%= Time.parse(time).strftime("%H:%M") %>
+                            </span>
+                          <% end %>
+                        <% else %>
+                          <span class="text-base-content/40">-</span>
+                        <% end %>
+                      </div>
+
+                      <div>
+                        <div class="text-xs text-base-content/70 mb-1"><%= t('history.index.bed_time') %></div>
+                        <% if record[:bed_times].present? %>
+                          <% record[:bed_times].each do |time| %>
+                            <span class="badge badge-secondary badge-sm mb-1 text-xs">
+                              <%= Time.parse(time).strftime("%H:%M") %>
+                            </span>
+                          <% end %>
+                        <% else %>
+                          <span class="text-base-content/40">-</span>
+                        <% end %>
+                      </div>
+
+                      <div>
+                        <div class="text-xs text-base-content/70 mb-1"><%= t('history.index.cumulative_wake_hours') %></div>
+                        <div class="text-accent text-sm font-semibold">
+                          <%= record[:cumulative_wake_hours] || '-' %>
+                        </div>
+                      </div>
+
+                      <div>
+                        <div class="text-xs text-base-content/70 mb-1"><%= t('history.index.cumulative_sleep_hours') %></div>
+                        <div class="text-info text-sm font-semibold">
+                          <%= record[:cumulative_sleep_hours] || '-' %>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </details>
+              </div>
+            <% end %>
+          </div>
+
+          <!-- デスクトップ用テーブル表示 -->
+          <div class="hidden md:block overflow-x-auto">
+            <table class="table table-zebra w-full border-t border-base-300 text-sm">
+              <thead class="bg-base-200">
+                <tr>
+                  <th class="px-4 py-3 text-sm"><%= t('history.index.date') %></th>
+                  <th class="px-4 py-3 text-sm"><%= t('history.index.wake_time') %></th>
+                  <th class="px-4 py-3 text-sm"><%= t('history.index.bed_time') %></th>
+                  <th class="px-4 py-3 text-sm"><%= t('history.index.daily_wake_hours') %></th>
+                  <th class="px-4 py-3 text-sm"><%= t('history.index.daily_sleep_hours') %></th>
+                  <th class="px-4 py-3 text-sm"><%= t('history.index.cumulative_wake_hours') %></th>
+                  <th class="px-4 py-3 text-sm"><%= t('history.index.cumulative_sleep_hours') %></th>
+                  <th class="px-4 py-3 text-sm">操作</th>
                 </tr>
-              <% end %>
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                <% @monthly_records.each do |record| %>
+                  <tr class="hover">
+                    <td class="px-4 py-3 whitespace-nowrap"><%= record[:day].is_a?(Date) ? record[:day].strftime("%m-%d (%a)") : '--' %></td>
+                    <td class="px-4 py-3">
+                      <% if record[:wake_times].present? %>
+                        <% record[:wake_times].each do |time| %>
+                          <span class="badge badge-success badge-sm mb-1 text-xs">
+                            <%= Time.parse(time).strftime("%m/%d_%H:%M") %>
+                          </span>
+                        <% end %>
+                      <% else %>
+                        <span class="text-base-content/40">-</span>
+                      <% end %>
+                    </td>
+                    <td class="px-4 py-3">
+                      <% if record[:bed_times].present? %>
+                        <% record[:bed_times].each do |time| %>
+                          <span class="badge badge-secondary badge-sm mb-1 text-xs">
+                            <%= Time.parse(time).strftime("%m/%d_%H:%M") %>
+                          </span>
+                        <% end %>
+                      <% else %>
+                        <span class="text-base-content/40">-</span>
+                      <% end %>
+                    </td>
+                    <td class="px-4 py-3 text-accent font-semibold">
+                      <%= record[:daily_wake_hours] ? sprintf("%.2f", record[:daily_wake_hours]) : '-' %>
+                    </td>
+                    <td class="px-4 py-3 text-info font-semibold">
+                      <%= record[:daily_sleep_hours] ? sprintf("%.2f", record[:daily_sleep_hours]) : '-' %>
+                    </td>
+                    <td class="px-4 py-3 text-accent text-sm font-semibold">
+                      <%= record[:cumulative_wake_hours] || '-' %>
+                    </td>
+                    <td class="px-4 py-3 text-info text-sm font-semibold">
+                      <%= record[:cumulative_sleep_hours] || '-' %>
+                    </td>
+                    <td class="px-4 py-3">
+                      <% if record[:id].present? %>
+                        <%= link_to '編集', edit_sleep_record_path(record[:id]), class: "btn btn-xs btn-outline whitespace-nowrap" %>
+                      <% else %>
+                        <%= link_to '追加', new_sleep_record_path(date: record[:day]), class: "btn btn-xs btn-outline btn-primary whitespace-nowrap" %>
+                      <% end %>
+                    </td>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
+          </div>
         </div>
       </details>
+    </div>
+
+    <!-- 月間統計 -->
+    <div class="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4 lg:gap-6">
+      <div class="card bg-base-100 border border-base-300 text-center p-3 sm:p-4">
+        <div class="text-[10px] sm:text-xs text-base-content/70 mb-1 sm:mb-2 leading-tight"><%= t('history.index.month_average_wake_hours') %></div>
+        <div class="text-lg sm:text-xl lg:text-2xl font-bold text-success">
+          <%= @month_average_wake_hours ? sprintf("%.2f", @month_average_wake_hours) : '-' %>h
+        </div>
+      </div>
+      <div class="card bg-base-100 border border-base-300 text-center p-3 sm:p-4">
+        <div class="text-[10px] sm:text-xs text-base-content/70 mb-1 sm:mb-2 leading-tight"><%= t('history.index.month_average_sleep_hours') %></div>
+        <div class="text-lg sm:text-xl lg:text-2xl font-bold text-info">
+          <%= @month_average_sleep_hours ? sprintf("%.2f", @month_average_sleep_hours) : '-' %>h
+        </div>
+      </div>
+      <div class="card bg-base-100 border border-base-300 text-center p-3 sm:p-4">
+        <div class="text-[10px] sm:text-xs text-base-content/70 mb-1 sm:mb-2 leading-tight"><%= t('history.index.month_average_wake_time') %></div>
+        <div class="text-lg sm:text-xl lg:text-2xl font-bold text-success">
+          <%= @month_average_wake_time || '-' %>
+        </div>
+      </div>
+      <div class="card bg-base-100 border border-base-300 text-center p-3 sm:p-4">
+        <div class="text-[10px] sm:text-xs text-base-content/70 mb-1 sm:mb-2 leading-tight"><%= t('history.index.month_average_bed_time') %></div>
+        <div class="text-lg sm:text-xl lg:text-2xl font-bold text-info">
+          <%= @month_average_bed_time || '-' %>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,7 +20,7 @@
 
   </head>
 
-  <body class="pb-16 pl-44">
+  <body class="pb-16 lg:pb-0 lg:pl-44">
     <%= render 'shared/flash' %>
 
     <div class="fixed inset-0 w-full h-full -z-10 pointer-events-none"
@@ -31,6 +31,10 @@
       <%= yield %>
     </main>
 
-    <%= render 'shared/sidebar' %>
+    <div class="hidden lg:block">
+      <%= render 'shared/sidebar' %>
+    </div>
+
+    <%= render 'shared/footer_nav' %>
   </body>
 </html>

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,4 +1,4 @@
-<div class="toast toast-top toast-center mt-10 ml-4 z-50">
+<div class="toast toast-top toast-center mt-10 lg:ml-20 z-50">
   <% flash.each do |key, message| %>
     <% alert_class =
       case key.to_sym

--- a/app/views/shared/_footer_nav.html.erb
+++ b/app/views/shared/_footer_nav.html.erb
@@ -1,0 +1,15 @@
+<div class="lg:hidden fixed bottom-0 left-0 right-0 bg-base-100 border-t border-base-300 z-20">
+  <nav class="flex justify-around items-center h-16">
+    <%= link_to dashboard_path,
+      class: "flex flex-col items-center justify-center flex-1 py-2.5 transition #{current_page?(dashboard_path) ? 'text-primary font-bold' : 'text-base-content/70'}" do %>
+      <i class="ph-fill ph-house text-2xl"></i>
+      <span class="text-xs mt-1"><%= t('sidebar.dashboard') %></span>
+    <% end %>
+
+    <%= link_to history_path,
+      class: "flex flex-col items-center justify-center flex-1 py-2.5 transition #{current_page?(history_path) ? 'text-primary font-bold' : 'text-base-content/70'}" do %>
+      <i class="ph-fill ph-clock-counter-clockwise text-2xl"></i>
+      <span class="text-xs mt-1"><%= t('sidebar.history') %></span>
+    <% end %>
+  </nav>
+</div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,6 +1,6 @@
 <div class="navbar p-4">
   <div class="navbar-start">
-    <h1 class="text-5xl font-bold text-base-content"><%= yield :page_title %></h1>
+    <h1 class="text-3xl font-bold text-base-content"><%= yield :page_title %></h1>
   </div>
   <div class="navbar-end flex gap-2 items-center">
     <div class="dropdown dropdown-end">

--- a/spec/system/dashboard_spec.rb
+++ b/spec/system/dashboard_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Dashboard", type: :system do
 
   it "起床記録ボタンが表示されていて押せること" do
     expect(page).to have_button(I18n.t('dashboard.index.wake_record'), disabled: false)
-    click_button I18n.t('dashboard.index.wake_record')
+    find('button[data-test="mobile-wake-button"], button[data-test="desktop-wake-button"]', match: :first).click
     expect(page).to have_content(I18n.t('dashboard.index.wake_record'))
   end
 
@@ -35,14 +35,14 @@ RSpec.describe "Dashboard", type: :system do
     FactoryBot.create(:sleep_record, :unbedded, user: user)
     visit dashboard_path
     expect(page).to have_button(I18n.t('dashboard.index.bed_record'), disabled: false)
-    click_button I18n.t('dashboard.index.bed_record')
+    find('button[data-test="mobile-bed-button"], button[data-test="desktop-bed-button"]', match: :first).click
     expect(page).to have_content(I18n.t('dashboard.index.bed_record'))
   end
 
   it "起床記録後に就寝記録ボタンが有効になること" do
-    click_button I18n.t('dashboard.index.wake_record')
+    find('button[data-test="mobile-wake-button"], button[data-test="desktop-wake-button"]', match: :first).click
     expect(page).to have_button(I18n.t('dashboard.index.bed_record'), disabled: false)
-    click_button I18n.t('dashboard.index.bed_record')
+    find('button[data-test="mobile-bed-button"], button[data-test="desktop-bed-button"]', match: :first).click
     expect(page).to have_content(I18n.t('dashboard.index.bed_record'))
   end
 end


### PR DESCRIPTION
## 概要
対応PR：Issue #53

## 対応内容
- レスポンシブ対応
- テーブルをモバイル向けアコーディオン式カード表示に変更
- アコーディオン閉じた状態では時刻のみ表示（SVGアイコン使用）
- チャート高さをレスポンシブ対応（250px→300px→350px）- ダッシュボードと履歴のグラフサイズを統一
- 統計カードのテキストサイズ最適化
- 記録ボタンから時刻表示を削除
- gap/marginをレスポンシブ対応

- フラッシュメッセージをモバイル時に中央表示
- フッターナビの高さ調整（h-16）とアイコンサイズ拡大
- bodyのpaddingをレスポンシブ対応"

## 目的
- モバイル表示時の情報が多いのでみやすくする

## 動作確認方法

## スクリーンショット / 動作イメージ（あれば）
<img width="394" height="848" alt="スクリーンショット 2025-11-08 0 40 51" src="https://github.com/user-attachments/assets/d190966f-e3e5-4831-9181-b2f1f1f395f4" />
<img width="394" height="848" alt="スクリーンショット 2025-11-08 0 40 37" src="https://github.com/user-attachments/assets/28e39382-c88d-4d02-a6ab-dd2514a01fde" />


## 備考
- <補足事項があれば>