### PR TITLE
Feat/accout delete #162

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable,
+         :rememberable, :validatable,
          :omniauthable, omniauth_providers: [ :google_oauth2 ]
 
   has_many :sleep_records, dependent: :destroy

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -28,12 +28,9 @@
         <%= f.password_field :password, autocomplete: "current-password", class: "input input-bordered w-full" %>
       </div>
 
-      <div class="form-control mb-4 flex items-center justify-between">
-        <div>
-          <%= f.check_box :remember_me, class: "checkbox checkbox-primary" %>
-          <%= f.label :remember_me, t('activerecord.attributes.user.remember_me') %>
-        </div>
-        <%= link_to t('devise.shared.links.forgot_your_password'), new_password_path(resource_name), class: "text-sm text-blue-500 hover:underline" %>
+      <div class="form-control mb-4">
+        <%= f.check_box :remember_me, class: "checkbox checkbox-primary" %>
+        <%= f.label :remember_me, t('activerecord.attributes.user.remember_me') %>
       </div>
 
       <div class="form-control">

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -18,7 +18,6 @@
         tabindex="-1"
         class="menu menu-sm dropdown-content bg-base-100 rounded-box z-1 mt-3 w-52 p-2 shadow border border-base-300">
           <li><%= link_to t('navbar.profile'), profile_path %></li>
-          <li><a><%= t('navbar.settings') %></a></li>
           <li class="menu-title mt-2">
             <span>情報</span>
           </li>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -43,6 +43,34 @@
               <%= button_to "Googleカレンダーと連携", user_google_oauth2_omniauth_authorize_path, method: :post, class: "btn btn-primary w-full", data: { turbo: false } %>
             <% end %>
           <% end %>
+
+          <div class="divider">アカウント管理</div>
+
+          <div class="collapse collapse-arrow bg-base-200">
+            <input type="checkbox" />
+            <div class="collapse-title text-sm font-medium text-error">
+              アカウントの削除
+            </div>
+            <div class="collapse-content">
+              <div class="alert alert-warning mt-2 mb-4">
+                <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                </svg>
+                <div>
+                  <h3 class="font-bold">警告</h3>
+                  <div class="text-xs">削除すると全ての睡眠記録が完全に失われます。この操作は取り消せません。</div>
+                </div>
+              </div>
+
+              <%= button_to "アカウントを削除する",
+                user_registration_path,
+                method: :delete,
+                class: "btn btn-error btn-outline w-full",
+                data: {
+                  turbo_confirm: "本当にアカウントを削除しますか？\n\nこの操作は取り消せません。すべての睡眠記録が完全に削除されます。"
+                } %>
+            </div>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
アカウント削除機能を実装し、パスワードリセット機能を無効化

- プロフィール表示ページにアカウント削除機能を追加
- 折りたたみ式UIで普段は非表示、クリックで展開
- 削除前に確認ダイアログを表示し、誤操作を防止
- 削除時に関連する睡眠記録も一括削除（dependent: :destroy）

- Deviseの:recoverableを削除し、パスワードリセット機能を無効化
- ログインページから「パスワードを忘れた場合」リンクを削除
- メール送信サービス不要でシンプルな構成に
- パスワードを忘れた場合はGoogle認証でログイン可能

- ドロップダウンメニューから「設定」リンクを削除
- プロフィールと設定の役割が重複していたため統合