### PR TITLE
レイアウト修正

### DIFF
--- a/app/assets/images/bg-summit.svg
+++ b/app/assets/images/bg-summit.svg
@@ -1,10 +1,149 @@
-<svg width="100%" height="100%" viewBox="0 0 1280 677" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="100%" height="100%" viewBox="0 0 1280 800" fill="none" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice">
   <defs>
-    <linearGradient id="fade-bottom" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="80%" stop-color="#049933" stop-opacity="0.38"/>
+    <!-- 遠景の山（薄い緑、より長いグラデーション） -->
+    <linearGradient id="mountain-far" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#049933" stop-opacity="0.12"/>
+      <stop offset="85%" stop-color="#049933" stop-opacity="0.02"/>
       <stop offset="100%" stop-color="#049933" stop-opacity="0"/>
     </linearGradient>
+
+    <!-- 近景の山（少し濃い緑、より長いグラデーション） -->
+    <linearGradient id="mountain-near" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#049933" stop-opacity="0.22"/>
+      <stop offset="80%" stop-color="#049933" stop-opacity="0.05"/>
+      <stop offset="100%" stop-color="#049933" stop-opacity="0"/>
+    </linearGradient>
+
+    <!-- 流れ星のグラデーション -->
+    <linearGradient id="shooting-star-1" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#fbbf24" stop-opacity="0"/>
+      <stop offset="30%" stop-color="#fbbf24" stop-opacity="0.6"/>
+      <stop offset="100%" stop-color="#fbbf24" stop-opacity="0.8"/>
+    </linearGradient>
+
+    <linearGradient id="shooting-star-2" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#fbbf24" stop-opacity="0"/>
+      <stop offset="30%" stop-color="#fbbf24" stop-opacity="0.5"/>
+      <stop offset="100%" stop-color="#fbbf24" stop-opacity="0.7"/>
+    </linearGradient>
   </defs>
-  <path d="M0 147C0 147 156.833 285 327.5 285C498.167 285 629.833 0.5 800.5 0.5C971.167 0.5 1280 165 1280 165V676.999C1280 676.999 1024 676.999 853.333 676.999C682.667 676.999 597.333 676.999 426.667 676.999C256 676.999 0 676.999 0 676.999V147Z" fill="url(#fade-bottom)"/>
-  <path d="M0 677C0 677 239.333 399.5 410 399.5C580.667 399.5 735.333 508.5 906 508.5C1076.67 508.5 1280 256 1280 256V677C1280 677 1024 677 853.333 677C682.667 677 597.333 677 426.667 677C256 677 0 677 0 677Z" fill="url(#fade-bottom)"/>
+
+  <!-- 遠景の山（下に移動） -->
+  <path d="M0 347C0 347 156.833 485 327.5 485C498.167 485 629.833 200.5 800.5 200.5C971.167 200.5 1280 365 1280 365V800H0V347Z" fill="url(#mountain-far)"/>
+
+  <!-- 近景の山（下に移動） -->
+  <path d="M0 800C0 800 239.333 549.5 410 549.5C580.667 549.5 735.333 658.5 906 658.5C1076.67 658.5 1280 456 1280 456V800H0Z" fill="url(#mountain-near)"/>
+
+  <!-- 流れ星 -->
+  <line x1="75%" y1="120" x2="82%" y2="160" stroke="url(#shooting-star-1)" stroke-width="2" stroke-linecap="round"/>
+  <circle cx="82%" cy="160" r="2.5" fill="#fbbf24" opacity="0.7"/>
+
+  <line x1="30%" y1="80" x2="35%" y2="115" stroke="url(#shooting-star-2)" stroke-width="1.5" stroke-linecap="round"/>
+  <circle cx="35%" cy="115" r="2" fill="#fbbf24" opacity="0.6"/>
+
+  <!-- 星を散りばめる -->
+  <!-- 大きめの星 -->
+  <circle cx="8%" cy="60" r="2" fill="#fbbf24" opacity="0.4"/>
+  <circle cx="22%" cy="85" r="1.8" fill="#fbbf24" opacity="0.35"/>
+  <circle cx="35%" cy="45" r="2.2" fill="#fbbf24" opacity="0.45"/>
+  <circle cx="48%" cy="70" r="1.9" fill="#fbbf24" opacity="0.38"/>
+  <circle cx="62%" cy="55" r="2.1" fill="#fbbf24" opacity="0.42"/>
+  <circle cx="75%" cy="90" r="2" fill="#fbbf24" opacity="0.37"/>
+  <circle cx="88%" cy="65" r="1.8" fill="#fbbf24" opacity="0.35"/>
+  <circle cx="95%" cy="80" r="2.2" fill="#fbbf24" opacity="0.43"/>
+  <circle cx="10%" cy="200" r="2.1" fill="#fbbf24" opacity="0.4"/>
+  <circle cx="40%" cy="180" r="2" fill="#fbbf24" opacity="0.38"/>
+  <circle cx="65%" cy="210" r="2.2" fill="#fbbf24" opacity="0.42"/>
+  <circle cx="90%" cy="190" r="1.9" fill="#fbbf24" opacity="0.39"/>
+
+  <!-- 中くらいの星 -->
+  <circle cx="12%" cy="110" r="1.4" fill="#fbbf24" opacity="0.28"/>
+  <circle cx="18%" cy="50" r="1.5" fill="#fbbf24" opacity="0.3"/>
+  <circle cx="28%" cy="120" r="1.3" fill="#fbbf24" opacity="0.26"/>
+  <circle cx="42%" cy="95" r="1.5" fill="#fbbf24" opacity="0.32"/>
+  <circle cx="52%" cy="35" r="1.4" fill="#fbbf24" opacity="0.28"/>
+  <circle cx="58%" cy="105" r="1.6" fill="#fbbf24" opacity="0.33"/>
+  <circle cx="68%" cy="75" r="1.3" fill="#fbbf24" opacity="0.26"/>
+  <circle cx="72%" cy="40" r="1.5" fill="#fbbf24" opacity="0.3"/>
+  <circle cx="82%" cy="115" r="1.4" fill="#fbbf24" opacity="0.28"/>
+  <circle cx="92%" cy="95" r="1.5" fill="#fbbf24" opacity="0.32"/>
+  <circle cx="15%" cy="170" r="1.5" fill="#fbbf24" opacity="0.3"/>
+  <circle cx="33%" cy="195" r="1.4" fill="#fbbf24" opacity="0.29"/>
+  <circle cx="50%" cy="220" r="1.6" fill="#fbbf24" opacity="0.32"/>
+  <circle cx="70%" cy="175" r="1.5" fill="#fbbf24" opacity="0.31"/>
+  <circle cx="85%" cy="230" r="1.4" fill="#fbbf24" opacity="0.28"/>
+  <circle cx="95%" cy="205" r="1.5" fill="#fbbf24" opacity="0.3"/>
+
+  <!-- 小さめの星 -->
+  <circle cx="5%" cy="85" r="1" fill="#fbbf24" opacity="0.22"/>
+  <circle cx="15%" cy="130" r="0.9" fill="#fbbf24" opacity="0.2"/>
+  <circle cx="25%" cy="65" r="1.1" fill="#fbbf24" opacity="0.24"/>
+  <circle cx="32%" cy="100" r="1" fill="#fbbf24" opacity="0.22"/>
+  <circle cx="38%" cy="30" r="0.9" fill="#fbbf24" opacity="0.2"/>
+  <circle cx="45%" cy="125" r="1.1" fill="#fbbf24" opacity="0.24"/>
+  <circle cx="55%" cy="85" r="1" fill="#fbbf24" opacity="0.22"/>
+  <circle cx="65%" cy="120" r="0.9" fill="#fbbf24" opacity="0.22"/>
+  <circle cx="70%" cy="50" r="1.1" fill="#fbbf24" opacity="0.24"/>
+  <circle cx="78%" cy="100" r="1" fill="#fbbf24" opacity="0.22"/>
+  <circle cx="85%" cy="35" r="0.9" fill="#fbbf24" opacity="0.2"/>
+  <circle cx="90%" cy="110" r="1.1" fill="#fbbf24" opacity="0.24"/>
+  <circle cx="97%" cy="55" r="1" fill="#fbbf24" opacity="0.22"/>
+  <circle cx="7%" cy="155" r="1" fill="#fbbf24" opacity="0.22"/>
+  <circle cx="20%" cy="240" r="1.1" fill="#fbbf24" opacity="0.23"/>
+  <circle cx="28%" cy="215" r="0.9" fill="#fbbf24" opacity="0.21"/>
+  <circle cx="43%" cy="165" r="1" fill="#fbbf24" opacity="0.22"/>
+  <circle cx="55%" cy="250" r="1.1" fill="#fbbf24" opacity="0.24"/>
+  <circle cx="62%" cy="185" r="1" fill="#fbbf24" opacity="0.22"/>
+  <circle cx="73%" cy="235" r="0.9" fill="#fbbf24" opacity="0.21"/>
+  <circle cx="80%" cy="245" r="1.1" fill="#fbbf24" opacity="0.23"/>
+  <circle cx="88%" cy="155" r="1" fill="#fbbf24" opacity="0.22"/>
+  <circle cx="93%" cy="170" r="1" fill="#fbbf24" opacity="0.22"/>
+  <circle cx="97%" cy="225" r="0.9" fill="#fbbf24" opacity="0.21"/>
+
+  <!-- さらに追加の星（より多く） -->
+  <!-- 大きめの星 -->
+  <circle cx="14%" cy="145" r="2" fill="#fbbf24" opacity="0.4"/>
+  <circle cx="26%" cy="160" r="1.9" fill="#fbbf24" opacity="0.38"/>
+  <circle cx="37%" cy="260" r="2.1" fill="#fbbf24" opacity="0.41"/>
+  <circle cx="49%" cy="140" r="2" fill="#fbbf24" opacity="0.39"/>
+  <circle cx="60%" cy="270" r="2.2" fill="#fbbf24" opacity="0.42"/>
+  <circle cx="77%" cy="145" r="1.9" fill="#fbbf24" opacity="0.38"/>
+  <circle cx="84%" cy="265" r="2.1" fill="#fbbf24" opacity="0.4"/>
+  <circle cx="96%" cy="150" r="2" fill="#fbbf24" opacity="0.39"/>
+
+  <!-- 中くらいの星 -->
+  <circle cx="3%" cy="115" r="1.5" fill="#fbbf24" opacity="0.3"/>
+  <circle cx="9%" cy="190" r="1.4" fill="#fbbf24" opacity="0.29"/>
+  <circle cx="17%" cy="220" r="1.6" fill="#fbbf24" opacity="0.32"/>
+  <circle cx="24%" cy="145" r="1.5" fill="#fbbf24" opacity="0.3"/>
+  <circle cx="31%" cy="255" r="1.4" fill="#fbbf24" opacity="0.29"/>
+  <circle cx="39%" cy="135" r="1.5" fill="#fbbf24" opacity="0.31"/>
+  <circle cx="46%" cy="205" r="1.6" fill="#fbbf24" opacity="0.32"/>
+  <circle cx="54%" cy="155" r="1.4" fill="#fbbf24" opacity="0.29"/>
+  <circle cx="61%" cy="240" r="1.5" fill="#fbbf24" opacity="0.3"/>
+  <circle cx="67%" cy="150" r="1.5" fill="#fbbf24" opacity="0.31"/>
+  <circle cx="75%" cy="220" r="1.4" fill="#fbbf24" opacity="0.29"/>
+  <circle cx="81%" cy="180" r="1.6" fill="#fbbf24" opacity="0.32"/>
+  <circle cx="89%" cy="210" r="1.5" fill="#fbbf24" opacity="0.3"/>
+  <circle cx="94%" cy="135" r="1.4" fill="#fbbf24" opacity="0.29"/>
+
+  <!-- 小さめの星 -->
+  <circle cx="2%" cy="140" r="1" fill="#fbbf24" opacity="0.22"/>
+  <circle cx="6%" cy="230" r="0.9" fill="#fbbf24" opacity="0.21"/>
+  <circle cx="11%" cy="260" r="1.1" fill="#fbbf24" opacity="0.23"/>
+  <circle cx="19%" cy="175" r="1" fill="#fbbf24" opacity="0.22"/>
+  <circle cx="23%" cy="190" r="0.9" fill="#fbbf24" opacity="0.21"/>
+  <circle cx="29%" cy="135" r="1" fill="#fbbf24" opacity="0.22"/>
+  <circle cx="35%" cy="225" r="1.1" fill="#fbbf24" opacity="0.23"/>
+  <circle cx="41%" cy="280" r="1" fill="#fbbf24" opacity="0.22"/>
+  <circle cx="47%" cy="245" r="0.9" fill="#fbbf24" opacity="0.21"/>
+  <circle cx="53%" cy="175" r="1.1" fill="#fbbf24" opacity="0.23"/>
+  <circle cx="59%" cy="145" r="1" fill="#fbbf24" opacity="0.22"/>
+  <circle cx="64%" cy="260" r="0.9" fill="#fbbf24" opacity="0.21"/>
+  <circle cx="69%" cy="195" r="1" fill="#fbbf24" opacity="0.22"/>
+  <circle cx="76%" cy="255" r="1.1" fill="#fbbf24" opacity="0.23"/>
+  <circle cx="83%" cy="140" r="1" fill="#fbbf24" opacity="0.22"/>
+  <circle cx="87%" cy="225" r="0.9" fill="#fbbf24" opacity="0.21"/>
+  <circle cx="91%" cy="250" r="1.1" fill="#fbbf24" opacity="0.23"/>
+  <circle cx="98%" cy="185" r="1" fill="#fbbf24" opacity="0.22"/>
 </svg>

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -38,3 +38,23 @@
   --depth: 1;
   --noise: 1;
 }
+
+/* カードを半透明に */
+.card.bg-base-100 {
+  background-color: oklch(24.353% 0 0 / 0.3) !important;
+  backdrop-filter: blur(1px);
+}
+
+.bg-base-100 {
+  background-color: oklch(24.353% 0 0 / 0.3) !important;
+}
+
+/* テーブルのストライプを薄く */
+.table-zebra tbody tr:nth-child(even) {
+  background-color: oklch(37% 0 0 / 0.15) !important;
+}
+
+/* テーブルのヘッダーを薄く */
+.table thead {
+  background-color: oklch(37% 0 0 / 0.2) !important;
+}

--- a/app/views/shared/_new_event_modal.html.erb
+++ b/app/views/shared/_new_event_modal.html.erb
@@ -7,102 +7,48 @@
       </form>
 
       <%= form_with url: google_calendars_path, method: :post, id: "new_event_form", class: "space-y-4", data: { turbo: false } do |f| %>
-        <!-- タイトル（常に表示） -->
+        <!-- タイトル -->
         <div class="form-control">
-          <%= text_field_tag :summary, nil, class: "input input-bordered input-lg w-full border-0 border-b border-base-300 rounded-none px-0 focus:border-primary focus:outline-none", placeholder: "タイトルを追加", required: true %>
+          <%= text_field_tag :summary, nil, class: "input input-bordered input-lg w-full", placeholder: "タイトルを追加", required: true %>
         </div>
 
-        <!-- シンプルモード：日時入力 -->
-        <div id="simple_mode" class="space-y-3">
-          <div class="flex items-center gap-3">
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-base-content/70" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-            </svg>
-            <div class="flex-1 flex items-center gap-2">
-              <%= date_field_tag :start_date, Date.current, class: "input input-sm input-bordered", required: true %>
-              <span class="text-sm">·</span>
-              <%= time_field_tag :start_time, Time.current.strftime("%H:%M"), class: "input input-sm input-bordered", required: true %>
-              <span class="text-sm text-base-content/50">-</span>
-              <%= time_field_tag :end_time, (Time.current + 1.hour).strftime("%H:%M"), class: "input input-sm input-bordered", required: true %>
-            </div>
+        <!-- 開始日時 -->
+        <div class="form-control">
+          <label class="label">
+            <span class="label-text font-semibold">開始日時</span>
+          </label>
+          <div class="grid grid-cols-2 gap-3">
+            <%= date_field_tag :start_date, Date.current, class: "input input-bordered input-lg", required: true %>
+            <%= time_field_tag :start_time, Time.current.strftime("%H:%M"), class: "input input-bordered input-lg", required: true %>
           </div>
-
-          <!-- 詳細を追加ボタン -->
-          <button type="button" onclick="toggleDetailMode()" class="btn btn-ghost btn-sm gap-2 text-primary">
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
-            </svg>
-            詳細を追加
-          </button>
         </div>
 
-        <!-- 詳細モード（初期状態で非表示） -->
-        <div id="detail_mode" class="space-y-4 hidden">
-          <!-- 開始日時 -->
-          <div class="flex items-start gap-3">
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-base-content/70 mt-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-            </svg>
-            <div class="flex-1 space-y-2">
-              <div class="grid grid-cols-2 gap-2">
-                <div class="form-control">
-                  <label class="label py-1">
-                    <span class="label-text text-xs">開始日</span>
-                  </label>
-                  <%= date_field_tag :start_date_detail, Date.current, class: "input input-sm input-bordered w-full" %>
-                </div>
-                <div class="form-control">
-                  <label class="label py-1">
-                    <span class="label-text text-xs">開始時刻</span>
-                  </label>
-                  <%= time_field_tag :start_time_detail, Time.current.strftime("%H:%M"), class: "input input-sm input-bordered w-full" %>
-                </div>
-              </div>
-              <div class="grid grid-cols-2 gap-2">
-                <div class="form-control">
-                  <label class="label py-1">
-                    <span class="label-text text-xs">終了日</span>
-                  </label>
-                  <%= date_field_tag :end_date, Date.current, class: "input input-sm input-bordered w-full" %>
-                </div>
-                <div class="form-control">
-                  <label class="label py-1">
-                    <span class="label-text text-xs">終了時刻</span>
-                  </label>
-                  <%= time_field_tag :end_time_detail, (Time.current + 1.hour).strftime("%H:%M"), class: "input input-sm input-bordered w-full" %>
-                </div>
-              </div>
-            </div>
+        <!-- 終了時刻 -->
+        <div class="form-control">
+          <label class="label">
+            <span class="label-text font-semibold">終了時刻</span>
+            <span class="label-text-alt text-base-content/60">※終了日は開始日と同じです</span>
+          </label>
+          <div class="grid grid-cols-2 gap-3">
+            <div></div>
+            <%= time_field_tag :end_time, (Time.current + 1.hour).strftime("%H:%M"), class: "input input-bordered input-lg", required: true %>
           </div>
+        </div>
 
-          <!-- 場所 -->
-          <div class="flex items-center gap-3">
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-base-content/70" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
-            </svg>
-            <div class="flex-1">
-              <%= text_field_tag :location, nil, class: "input input-sm input-bordered w-full", placeholder: "場所を追加" %>
-            </div>
-          </div>
+        <!-- 場所 -->
+        <div class="form-control">
+          <label class="label">
+            <span class="label-text font-semibold">場所（任意）</span>
+          </label>
+          <%= text_field_tag :location, nil, class: "input input-bordered input-lg w-full", placeholder: "場所を追加" %>
+        </div>
 
-          <!-- 説明 -->
-          <div class="flex items-start gap-3">
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-base-content/70 mt-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h7" />
-            </svg>
-            <div class="flex-1">
-              <%= text_area_tag :description, nil, class: "textarea textarea-bordered w-full", rows: 3, placeholder: "説明を追加" %>
-            </div>
-          </div>
-
-          <!-- 詳細を閉じるボタン -->
-          <button type="button" onclick="toggleDetailMode()" class="btn btn-ghost btn-sm gap-2 text-base-content/70">
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18 12H6" />
-            </svg>
-            詳細を閉じる
-          </button>
+        <!-- 説明 -->
+        <div class="form-control">
+          <label class="label">
+            <span class="label-text font-semibold">説明（任意）</span>
+          </label>
+          <%= text_area_tag :description, nil, class: "textarea textarea-bordered w-full", rows: 3, placeholder: "説明を追加" %>
         </div>
 
         <!-- アクションボタン -->

--- a/app/views/shared/_sleep_record_modal.html.erb
+++ b/app/views/shared/_sleep_record_modal.html.erb
@@ -1,0 +1,225 @@
+<!-- 睡眠記録作成・編集モーダル -->
+<dialog id="sleep_record_modal" class="modal">
+  <div class="modal-box max-w-2xl">
+    <form method="dialog">
+      <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
+    </form>
+
+    <h2 class="text-2xl font-bold mb-6" id="sleep_record_modal_title">睡眠記録を追加</h2>
+
+    <%= form_with model: SleepRecord.new, id: "sleep_record_form", class: "space-y-4", data: { turbo: false } do |f| %>
+      <div id="sleep_record_errors" class="hidden alert alert-error mb-4">
+        <ul id="sleep_record_error_list"></ul>
+      </div>
+
+      <!-- 起床時刻 -->
+      <div class="form-control">
+        <label class="label">
+          <span class="label-text font-semibold flex items-center gap-2">
+            <i class="ph-fill ph-sun text-warning text-lg"></i>
+            起床時刻
+          </span>
+          <span class="label-text-alt text-base-content/60">※未来の時刻は設定できません</span>
+        </label>
+
+        <div class="grid grid-cols-2 gap-3">
+          <%= f.date_field :wake_date,
+              class: "input input-bordered input-lg",
+              required: true,
+              id: "modal_wake_date" %>
+          <%= f.time_field :wake_time_only,
+              class: "input input-bordered input-lg",
+              required: true,
+              id: "modal_wake_time_only" %>
+        </div>
+
+        <%= f.hidden_field :wake_time, id: "modal_wake_time" %>
+      </div>
+
+      <!-- 就寝時刻 -->
+      <div class="form-control">
+        <label class="label">
+          <span class="label-text font-semibold flex items-center gap-2">
+            <i class="ph-fill ph-moon text-info text-lg"></i>
+            就寝時刻
+          </span>
+          <span class="label-text-alt text-base-content/60">※未来の時刻は設定できません</span>
+        </label>
+
+        <div class="grid grid-cols-2 gap-3">
+          <%= f.date_field :bed_date,
+              class: "input input-bordered input-lg",
+              id: "modal_bed_date" %>
+          <%= f.time_field :bed_time_only,
+              class: "input input-bordered input-lg",
+              id: "modal_bed_time_only" %>
+        </div>
+
+        <%= f.hidden_field :bed_time, id: "modal_bed_time" %>
+      </div>
+
+      <div class="flex justify-end gap-2 pt-4 border-t border-base-300">
+        <button type="button" onclick="sleep_record_modal.close()" class="btn btn-outline">キャンセル</button>
+        <%= f.submit "作成", class: "btn btn-primary", id: "sleep_record_submit_btn" %>
+      </div>
+    <% end %>
+  </div>
+  <form method="dialog" class="modal-backdrop">
+    <button>close</button>
+  </form>
+</dialog>
+
+<script>
+  // 日付と時刻を結合してhiddenフィールドに設定
+  function updateWakeTimeHidden() {
+    const date = document.getElementById('modal_wake_date').value;
+    const time = document.getElementById('modal_wake_time_only').value;
+    if (date && time) {
+      document.getElementById('modal_wake_time').value = `${date}T${time}`;
+    }
+  }
+
+  function updateBedTimeHidden() {
+    const date = document.getElementById('modal_bed_date').value;
+    const time = document.getElementById('modal_bed_time_only').value;
+    if (date && time) {
+      document.getElementById('modal_bed_time').value = `${date}T${time}`;
+    } else {
+      document.getElementById('modal_bed_time').value = '';
+    }
+  }
+
+  window.openSleepRecordModal = function(mode, recordId = null, wakeTime = null, bedTime = null, date = null) {
+    const modal = document.getElementById('sleep_record_modal');
+    const form = document.getElementById('sleep_record_form');
+    const title = document.getElementById('sleep_record_modal_title');
+    const submitBtn = document.getElementById('sleep_record_submit_btn');
+    const errorsDiv = document.getElementById('sleep_record_errors');
+
+    // エラー表示をクリア
+    errorsDiv.classList.add('hidden');
+
+    if (mode === 'new') {
+      title.textContent = '睡眠記録を追加';
+      form.action = '/sleep_records';
+      form.querySelector('input[name="_method"]')?.remove();
+      submitBtn.textContent = '作成';
+
+      // dateパラメータがある場合、起床時刻のデフォルト値を設定
+      if (date) {
+        const defaultDate = new Date(date);
+        document.getElementById('modal_wake_date').value = date;
+        document.getElementById('modal_wake_time_only').value = '07:00';
+        updateWakeTimeHidden();
+      } else {
+        const now = new Date();
+        document.getElementById('modal_wake_date').value = now.toISOString().split('T')[0];
+        document.getElementById('modal_wake_time_only').value = now.toTimeString().slice(0, 5);
+        updateWakeTimeHidden();
+      }
+
+      document.getElementById('modal_bed_date').value = '';
+      document.getElementById('modal_bed_time_only').value = '';
+      document.getElementById('modal_bed_time').value = '';
+    } else if (mode === 'edit') {
+      title.textContent = '睡眠記録を編集';
+      form.action = `/sleep_records/${recordId}`;
+
+      // PATCH methodを追加
+      let methodInput = form.querySelector('input[name="_method"]');
+      if (!methodInput) {
+        methodInput = document.createElement('input');
+        methodInput.type = 'hidden';
+        methodInput.name = '_method';
+        form.insertBefore(methodInput, form.firstChild);
+      }
+      methodInput.value = 'patch';
+
+      submitBtn.textContent = '更新';
+
+      // 起床時刻を分離
+      if (wakeTime) {
+        const [wakeDate, wakeTimeOnly] = wakeTime.split('T');
+        document.getElementById('modal_wake_date').value = wakeDate;
+        document.getElementById('modal_wake_time_only').value = wakeTimeOnly;
+        document.getElementById('modal_wake_time').value = wakeTime;
+      }
+
+      // 就寝時刻を分離
+      if (bedTime) {
+        const [bedDate, bedTimeOnly] = bedTime.split('T');
+        document.getElementById('modal_bed_date').value = bedDate;
+        document.getElementById('modal_bed_time_only').value = bedTimeOnly;
+        document.getElementById('modal_bed_time').value = bedTime;
+      } else {
+        document.getElementById('modal_bed_date').value = '';
+        document.getElementById('modal_bed_time_only').value = '';
+        document.getElementById('modal_bed_time').value = '';
+      }
+    }
+
+    modal.showModal();
+  };
+
+  // フォーム送信時の処理
+  document.addEventListener('DOMContentLoaded', function() {
+    // 日付・時刻フィールドの変更を監視
+    const wakeDate = document.getElementById('modal_wake_date');
+    const wakeTimeOnly = document.getElementById('modal_wake_time_only');
+    const bedDate = document.getElementById('modal_bed_date');
+    const bedTimeOnly = document.getElementById('modal_bed_time_only');
+
+    if (wakeDate && wakeTimeOnly) {
+      wakeDate.addEventListener('change', updateWakeTimeHidden);
+      wakeTimeOnly.addEventListener('change', updateWakeTimeHidden);
+    }
+
+    if (bedDate && bedTimeOnly) {
+      bedDate.addEventListener('change', updateBedTimeHidden);
+      bedTimeOnly.addEventListener('change', updateBedTimeHidden);
+    }
+
+    const form = document.getElementById('sleep_record_form');
+    if (form) {
+      form.addEventListener('submit', function(e) {
+        e.preventDefault();
+
+        // 送信前に最新の値を更新
+        updateWakeTimeHidden();
+        updateBedTimeHidden();
+
+        const formData = new FormData(form);
+        const url = form.action;
+        const method = form.querySelector('input[name="_method"]')?.value || 'POST';
+
+        fetch(url, {
+          method: method === 'patch' ? 'PATCH' : 'POST',
+          body: formData,
+          headers: {
+            'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content,
+            'Accept': 'text/html'
+          }
+        }).then(response => {
+          if (response.ok) {
+            window.location.reload();
+          } else {
+            return response.json().then(data => {
+              const errorsDiv = document.getElementById('sleep_record_errors');
+              const errorList = document.getElementById('sleep_record_error_list');
+              errorList.innerHTML = '';
+
+              if (data.errors) {
+                data.errors.forEach(error => {
+                  const li = document.createElement('li');
+                  li.textContent = error;
+                  errorList.appendChild(li);
+                });
+                errorsDiv.classList.remove('hidden');
+              }
+            });
+          }
+        });
+      });
+    }
+  });
+</script>


### PR DESCRIPTION
- 背景SVGに星空を追加（黄色の星90個以上、流れ星2つ）
- カードとテーブルを半透明化して背景が透けるように
- 睡眠記録の作成・編集をモーダル化
- 日付と時刻を分離した入力フィールド
- モバイルでタップしやすい大きなフィールド

- カレンダーモーダルもシンプル化して同じ操作感に

- 注釈を右側に配置してスペース効率化 