### PR TITLE
記録編集、追加機能btn無効化

### DIFF
--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -58,11 +58,13 @@
                             <h4 class="font-bold text-sm">
                               <%= record[:day].is_a?(Date) ? record[:day].strftime("%m-%d (%a)") : '--' %>
                             </h4>
+                            <!-- 操作系統コメントアウト
                             <% if record[:id].present? %>
                               <button onclick="event.stopPropagation(); openSleepRecordModal('edit', <%= record[:id] %>, '<%= record[:wake_times].present? ? Time.parse(record[:wake_times].first).strftime('%Y-%m-%dT%H:%M') : '' %>', '<%= record[:bed_times].present? ? Time.parse(record[:bed_times].last).strftime('%Y-%m-%dT%H:%M') : '' %>')" class="btn btn-xs btn-outline">編集</button>
                             <% else %>
                               <button onclick="event.stopPropagation(); openSleepRecordModal('new', null, null, null, '<%= record[:day] %>')" class="btn btn-xs btn-outline btn-primary">追加</button>
                             <% end %>
+                            -->
                           </div>
                           <div class="text-xs text-base-content/70 flex gap-4">
                             <span class="flex items-center gap-1">
@@ -146,7 +148,7 @@
                       <th class="px-4 py-3 text-sm font-semibold text-base-content/70"><%= t('dashboard.index.daily_sleep_hours') %></th>
                       <th class="px-4 py-3 text-sm font-semibold text-base-content/70"><%= t('dashboard.index.cumulative_wake_hours') %></th>
                       <th class="px-4 py-3 text-sm font-semibold text-base-content/70"><%= t('dashboard.index.cumulative_sleep_hours') %></th>
-                      <th class="px-4 py-3 text-sm font-semibold text-base-content/70">操作</th>
+                      <%# <th class="px-4 py-3 text-sm font-semibold text-base-content/70">操作</th> %>
                     </tr>
                   </thead>
                   <tbody>
@@ -189,12 +191,14 @@
                         <td class="px-4 py-3 text-info text-sm font-semibold">
                           <%= record[:cumulative_sleep_hours] || '-' %>
                         </td>
+                        <!-- 操作系統コメントアウト
                         <td class="px-4 py-3">
                           <% if record[:id].present? %>
                             <button onclick="openSleepRecordModal('edit', <%= record[:id] %>, '<%= record[:wake_times].present? ? Time.parse(record[:wake_times].first).strftime('%Y-%m-%dT%H:%M') : '' %>', '<%= record[:bed_times].present? ? Time.parse(record[:bed_times].last).strftime('%Y-%m-%dT%H:%M') : '' %>')" class="btn btn-xs btn-outline whitespace-nowrap">編集</button>
                           <% else %>
                             <button onclick="openSleepRecordModal('new', null, null, null, '<%= record[:day] %>')" class="btn btn-xs btn-outline btn-primary whitespace-nowrap">追加</button>
                           <% end %>
+                        -->
                         </td>
                       </tr>
                     <% end %>

--- a/app/views/history/index.html.erb
+++ b/app/views/history/index.html.erb
@@ -50,11 +50,13 @@
                         <h4 class="font-bold text-sm">
                           <%= record[:day].is_a?(Date) ? record[:day].strftime("%m-%d (%a)") : '--' %>
                         </h4>
+                        <!-- 操作系統コメントアウト
                         <% if record[:id].present? %>
                           <button onclick="event.stopPropagation(); openSleepRecordModal('edit', <%= record[:id] %>, '<%= record[:wake_times].present? ? Time.parse(record[:wake_times].first).strftime('%Y-%m-%dT%H:%M') : '' %>', '<%= record[:bed_times].present? ? Time.parse(record[:bed_times].last).strftime('%Y-%m-%dT%H:%M') : '' %>')" class="btn btn-xs btn-outline">編集</button>
                         <% else %>
                           <button onclick="event.stopPropagation(); openSleepRecordModal('new', null, null, null, '<%= record[:day] %>')" class="btn btn-xs btn-outline btn-primary">追加</button>
                         <% end %>
+                        -->
                       </div>
                       <div class="text-xs text-base-content/70 flex gap-4">
                         <span class="flex items-center gap-1">
@@ -138,7 +140,7 @@
                   <th class="px-4 py-3 text-sm"><%= t('history.index.daily_sleep_hours') %></th>
                   <th class="px-4 py-3 text-sm"><%= t('history.index.cumulative_wake_hours') %></th>
                   <th class="px-4 py-3 text-sm"><%= t('history.index.cumulative_sleep_hours') %></th>
-                  <th class="px-4 py-3 text-sm">操作</th>
+                  <%# <th class="px-4 py-3 text-sm">操作</th> %>
                 </tr>
               </thead>
               <tbody>
@@ -179,6 +181,7 @@
                     <td class="px-4 py-3 text-info text-sm font-semibold">
                       <%= record[:cumulative_sleep_hours] || '-' %>
                     </td>
+                    <!-- 操作系統コメントアウト
                     <td class="px-4 py-3">
                       <% if record[:id].present? %>
                         <button onclick="openSleepRecordModal('edit', <%= record[:id] %>, '<%= record[:wake_times].present? ? Time.parse(record[:wake_times].first).strftime('%Y-%m-%dT%H:%M') : '' %>', '<%= record[:bed_times].present? ? Time.parse(record[:bed_times].last).strftime('%Y-%m-%dT%H:%M') : '' %>')" class="btn btn-xs btn-outline whitespace-nowrap">編集</button>
@@ -186,6 +189,7 @@
                         <button onclick="openSleepRecordModal('new', null, null, null, '<%= record[:day] %>')" class="btn btn-xs btn-outline btn-primary whitespace-nowrap">追加</button>
                       <% end %>
                     </td>
+                    -->
                   </tr>
                 <% end %>
               </tbody>


### PR DESCRIPTION
ユーザーが前後の睡眠時間以上の値を入力時にグラフが崩れてしまうため廃止
後に機能追加は予定しているがまずは記録を保存できることが第一で記録を編集する機能は一旦不要と考える