### PR TITLE
デプロイ時にアイコンが変更できない不具合を修正

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,11 @@ class User < ApplicationRecord
   # 新規登録時は選択しないため更新時のみバリデーションを行う
   validates :avatar, presence: true, on: :update
 
+  def avatar_filename
+    return "default.png" if avatar.blank?
+    avatar.to_s.include?(".") ? avatar : "#{avatar}.png"
+  end
+
   # Google認証済みかどうかを判定
   def google_authenticated?
     return false unless ENV["GOOGLE_CLIENT_ID"].present? && ENV["GOOGLE_CLIENT_SECRET"].present?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,6 +17,15 @@ class User < ApplicationRecord
     avatar.to_s.include?(".") ? avatar : "#{avatar}.png"
   end
 
+  def avatar=(value)
+    normalized = if value.present? && !value.to_s.include?(".")
+      "#{value}.png"
+    else
+      value
+    end
+    super(normalized)
+  end
+
   # Google認証済みかどうかを判定
   def google_authenticated?
     return false unless ENV["GOOGLE_CLIENT_ID"].present? && ENV["GOOGLE_CLIENT_SECRET"].present?

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -10,7 +10,7 @@
         </span>
         <div class="w-10 rounded-full overflow-hidden">
           <label>
-            <%= image_tag "avatars/#{current_user.avatar || 'default.png'}", size: "50x50" %>
+            <%= image_tag "avatars/#{current_user.avatar_filename}", size: "50x50" %>
           </label>
         </div>
       </div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -14,10 +14,10 @@
     <div>
       <%= f.label :avatar, t('profiles.edit.avatar_label') %>
       <div class="flex gap-6 mt-2">
-        <% ["default.png", "boy-1.png", "boy-2.png", "girl-1.png", "girl-2.png"].each do |img| %>
+        <% ["default", "boy-1", "boy-2", "girl-1", "girl-2"].each do |img| %>
           <label class="flex flex-col items-center cursor-pointer">
             <%= f.radio_button :avatar, img, id: img, class: "radio radio-primary mb-2" %>
-            <%= image_tag "avatars/#{img}", size: "50x50", class: "rounded-full border border-base-300" %>
+            <%= image_tag "avatars/#{img}.png", size: "50x50", class: "rounded-full border border-base-300" %>
           </label>
         <% end %>
       </div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -2,31 +2,30 @@
   <%= t('profiles.edit.page_title') %>
 <% end %>
 
-    <div class="card bg-base-100 border border-base-300 p-8 max-w-lg mx-auto">
-      <div class="flex flex-col items-center">
-        <%= form_with model: current_user, url: profile_path, method: :patch, local: true do |f| %>
-  <%= render 'shared/error_messages', object: current_user %>
-  
-  <div>
-    <%= f.label :name, t('profiles.edit.name_label') %>
-    <%= f.text_field :name, class: "input input-bordered w-full mb-4" %>
-  </div>
-
-  <div>
-    <%= f.label :avatar, t('profiles.edit.avatar_label') %>
-    <div class="flex gap-6 mt-2">
-      <% ["default", "boy-1", "boy-2", "girl-1", "girl-2"].each do |img| %>
-        <label class="flex flex-col items-center cursor-pointer">
-          <%= f.radio_button :avatar, img, id: img, class: "radio radio-primary mb-2" %>
-          <%= image_tag "avatars/#{img}", size: "50x50", class: "rounded-full border border-base-300" %>
-        </label>
-      <% end %>
+<div class="card bg-base-100 border border-base-300 p-8 max-w-lg mx-auto">
+  <div class="flex flex-col items-center">
+    <%= form_with model: current_user, url: profile_path, method: :patch, local: true do |f| %>
+    <%= render 'shared/error_messages', object: current_user %>
+    <div>
+      <%= f.label :name, t('profiles.edit.name_label') %>
+      <%= f.text_field :name, class: "input input-bordered w-full mb-4" %>
     </div>
-      </div>
 
-      <div class="mt-6 flex justify-center">
-        <%= f.submit t('profiles.edit.submit'), class: "btn btn-primary" %>
+    <div>
+      <%= f.label :avatar, t('profiles.edit.avatar_label') %>
+      <div class="flex gap-6 mt-2">
+        <% ["default.png", "boy-1.png", "boy-2.png", "girl-1.png", "girl-2.png"].each do |img| %>
+          <label class="flex flex-col items-center cursor-pointer">
+            <%= f.radio_button :avatar, img, id: img, class: "radio radio-primary mb-2" %>
+            <%= image_tag "avatars/#{img}", size: "50x50", class: "rounded-full border border-base-300" %>
+          </label>
+        <% end %>
       </div>
+    </div>
+
+    <div class="mt-6 flex justify-center">
+      <%= f.submit t('profiles.edit.submit'), class: "btn btn-primary" %>
+    </div>
     <% end %>
-      </div>
-    </div>
+  </div>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -4,11 +4,7 @@
 
     <div class="card bg-base-100 border border-base-300 p-8 max-w-lg mx-auto">
       <div class="flex flex-col items-center">
-        <% if @user.avatar.present? %>
-          <%= image_tag "avatars/#{@user.avatar}", alt: t('profiles.edit.avatar_label'), class: "w-20 h-20 rounded-full mb-4" %>
-        <% else %>
-          <%= image_tag "avatars/default.png", alt: t('profiles.edit.avatar_label'), class: "w-20 h-20 rounded-full mb-4" %>
-        <% end %>
+        <%= image_tag "avatars/#{@user.avatar_filename}", alt: t('profiles.edit.avatar_label'), class: "w-20 h-20 rounded-full mb-4" %>
         <%= t('profiles.show.user_name') %>: <%= @user.name %>
 
         <div class="mt-6 space-y-4 w-full">


### PR DESCRIPTION
Userにavatar_filenameを追加し、拡張子なしの既存データでも.pngに正規化して表示できる

ビュー側をすべて拡張子付き参照に統一（選択肢の値も.png付き）

## 動作確認
プロフィール編集で任意のアバターを選択→保存→プロフィール/ナビバーで即時反映
既存ユーザー（avatarが拡張子なし）の表示も崩れないことを確認
システムテスト実行
rspec spec/system/profile_edit_spec.rb がパス
