### PR TITLE
Fix/sleep chart

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -11,21 +11,22 @@ class DashboardController < ApplicationController
 
     aggregator = SleepRecordAggregator.new(@week_records)
     week_days = (week_start.to_date..week_end.to_date).to_a
-    @weekly_records = aggregator.build_cumulative(week_days)
+    @weekly_records = aggregator.build_cumulative(week_days, exclude_prev_record: true)
 
     @series = SleepRecordChartBuilder.new(@week_records).build_series(range: week_start..week_end)
 
     # 日ごと集計して平均を計算（累計 ÷ 記録のある日数）
-    valid_days = @weekly_records.select { |d| d[:daily_sleep_hours].present? && d[:daily_wake_hours].present? }
+    valid_wake_days = @weekly_records.select { |d| d[:day].is_a?(Date) && d[:daily_wake_hours].present? }
+    valid_sleep_days = @weekly_records.select { |d| d[:day].is_a?(Date) && d[:daily_sleep_hours].present? }
 
-    @weekly_average_sleep_hours = if valid_days.any?
-      (valid_days.sum { |d| d[:daily_sleep_hours] } / valid_days.size).round(2)
+    @weekly_average_wake_hours = if valid_wake_days.any?
+      (valid_wake_days.sum { |d| d[:daily_wake_hours] } / valid_wake_days.size).round(2)
     else
       0.0
     end
 
-    @weekly_average_wake_hours = if valid_days.any?
-      (valid_days.sum { |d| d[:daily_wake_hours] } / valid_days.size).round(2)
+    @weekly_average_sleep_hours = if valid_sleep_days.any?
+      (valid_sleep_days.sum { |d| d[:daily_sleep_hours] } / valid_sleep_days.size).round(2)
     else
       0.0
     end

--- a/app/controllers/history_controller.rb
+++ b/app/controllers/history_controller.rb
@@ -13,15 +13,16 @@ class HistoryController < ApplicationController
 
     month_days = (start_date..end_date).to_a
     aggregator = SleepRecordAggregator.new(finished_records)
-    @monthly_records = aggregator.build_cumulative(month_days)
+    @monthly_records = aggregator.build_cumulative(month_days, exclude_prev_record: true)
 
     @series = SleepRecordChartBuilder.new(sleep_records).build_series(range: start_date.beginning_of_day..end_date.end_of_day)
 
     # 日ごと集計して平均を計算（累計 ÷ 記録のある日数）
-    valid_days = @monthly_records.select { |d| d[:daily_sleep_hours].present? && d[:daily_wake_hours].present? }
+    valid_wake_days = @monthly_records.select { |d| d[:day].is_a?(Date) && d[:day] < Date.current && d[:daily_wake_hours].present? }
+    valid_sleep_days = @monthly_records.select { |d| d[:day].is_a?(Date) && d[:day] < Date.current && d[:daily_sleep_hours].present? }
 
-    @month_average_sleep_hours = valid_days.any? ? (valid_days.sum { |d| d[:daily_sleep_hours] } / valid_days.size).round(2) : 0.0
-    @month_average_wake_hours  = valid_days.any? ? (valid_days.sum { |d| d[:daily_wake_hours] } / valid_days.size).round(2) : 0.0
+    @month_average_wake_hours = valid_wake_days.any? ? (valid_wake_days.sum { |d| d[:daily_wake_hours] } / valid_wake_days.size).round(2) : 0.0
+    @month_average_sleep_hours = valid_sleep_days.any? ? (valid_sleep_days.sum { |d| d[:daily_sleep_hours] } / valid_sleep_days.size).round(2) : 0.0
 
     valid_wake_records  = finished_records.select { |r| r.wake_time.present? }
     valid_sleep_records = finished_records.select { |r| r.wake_time.present? && r.bed_time.present? }

--- a/app/controllers/sleep_records_controller.rb
+++ b/app/controllers/sleep_records_controller.rb
@@ -75,7 +75,7 @@ class SleepRecordsController < ApplicationController
 
     # 当日以降のレコードは作成不可
     if attributes[:wake_time] && attributes[:wake_time].to_date >= Time.current.to_date
-      return render json: { errors: [I18n.t("sleep_records.create.cannot_create_today_or_later")] }, status: :unprocessable_entity
+      return render json: { errors: [ I18n.t("sleep_records.create.cannot_create_today_or_later") ] }, status: :unprocessable_entity
     end
 
     @sleep_record = current_user.sleep_records.build(attributes)

--- a/app/controllers/sleep_records_controller.rb
+++ b/app/controllers/sleep_records_controller.rb
@@ -33,6 +33,10 @@ class SleepRecordsController < ApplicationController
   end
 
   def edit
+    # 当日以降のレコードは編集不可
+    if @sleep_record.wake_time.to_date >= Time.current.to_date
+      return redirect_with_flash(:alert, I18n.t("sleep_records.edit.cannot_edit_today_or_later"))
+    end
     session[:return_to] = request.referer
   end
 
@@ -68,6 +72,11 @@ class SleepRecordsController < ApplicationController
     attributes = {}
     attributes[:wake_time] = Time.zone.parse(wake_time_param) if wake_time_param.present?
     attributes[:bed_time] = Time.zone.parse(bed_time_param) if bed_time_param.present?
+
+    # 当日以降のレコードは作成不可
+    if attributes[:wake_time] && attributes[:wake_time].to_date >= Time.current.to_date
+      return render json: { errors: [I18n.t("sleep_records.create.cannot_create_today_or_later")] }, status: :unprocessable_entity
+    end
 
     @sleep_record = current_user.sleep_records.build(attributes)
 

--- a/app/models/sleep_record.rb
+++ b/app/models/sleep_record.rb
@@ -39,5 +39,4 @@ class SleepRecord < ApplicationRecord
       errors.add(:wake_time, "前回の就寝時刻（#{previous_record.bed_time.strftime('%m月%d日 %H:%M')}）より後に設定してください")
     end
   end
-
 end

--- a/app/services/sleep_record_aggregator.rb
+++ b/app/services/sleep_record_aggregator.rb
@@ -39,11 +39,11 @@ class SleepRecordAggregator
     wake_total
   end
 
-  def build_cumulative(days_range)
+  def build_cumulative(days_range, exclude_prev_record: false)
     return [] if @records.empty?
     sorted = @records.select { |r| r.wake_time.present? }.sort_by(&:wake_time)
 
-    prev_record = if sorted.first
+    prev_record = if !exclude_prev_record && sorted.first
       user = sorted.first.user
       range_start = days_range.first
       if range_start == range_start.beginning_of_month

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -60,9 +60,13 @@
                               <%= record[:day].is_a?(Date) ? record[:day].strftime("%m-%d (%a)") : '--' %>
                             </h4>
                             <% if record[:id].present? %>
-                              <button onclick="event.stopPropagation(); openSleepRecordModal('edit', <%= record[:id] %>, '<%= record[:wake_times].present? ? Time.parse(record[:wake_times].first).strftime('%Y-%m-%dT%H:%M') : '' %>', '<%= record[:bed_times].present? ? Time.parse(record[:bed_times].last).strftime('%Y-%m-%dT%H:%M') : '' %>')" class="btn btn-xs btn-outline">編集</button>
+                              <% if record[:day].is_a?(Date) && record[:day].to_date < Time.current.to_date %>
+                                <button onclick="event.stopPropagation(); openSleepRecordModal('edit', <%= record[:id] %>, '<%= record[:wake_times].present? ? Time.parse(record[:wake_times].first).strftime('%Y-%m-%dT%H:%M') : '' %>', '<%= record[:bed_times].present? ? Time.parse(record[:bed_times].last).strftime('%Y-%m-%dT%H:%M') : '' %>')" class="btn btn-xs btn-outline">編集</button>
+                              <% end %>
                             <% else %>
-                              <button onclick="event.stopPropagation(); openSleepRecordModal('new', null, null, null, '<%= record[:day] %>')" class="btn btn-xs btn-outline btn-primary">追加</button>
+                              <% if record[:day].is_a?(Date) && record[:day].to_date < Time.current.to_date %>
+                                <button onclick="event.stopPropagation(); openSleepRecordModal('new', null, null, null, '<%= record[:day] %>')" class="btn btn-xs btn-outline btn-primary">追加</button>
+                              <% end %>
                             <% end %>
                           </div>
                           <div class="text-xs text-base-content/70 flex gap-4">
@@ -192,9 +196,13 @@
                         </td>
                         <td class="px-4 py-3">
                           <% if record[:id].present? %>
-                            <button onclick="openSleepRecordModal('edit', <%= record[:id] %>, '<%= record[:wake_times].present? ? Time.parse(record[:wake_times].first).strftime('%Y-%m-%dT%H:%M') : '' %>', '<%= record[:bed_times].present? ? Time.parse(record[:bed_times].last).strftime('%Y-%m-%dT%H:%M') : '' %>')" class="btn btn-xs btn-outline whitespace-nowrap">編集</button>
+                            <% if record[:day].is_a?(Date) && record[:day].to_date < Time.current.to_date %>
+                              <button onclick="openSleepRecordModal('edit', <%= record[:id] %>, '<%= record[:wake_times].present? ? Time.parse(record[:wake_times].first).strftime('%Y-%m-%dT%H:%M') : '' %>', '<%= record[:bed_times].present? ? Time.parse(record[:bed_times].last).strftime('%Y-%m-%dT%H:%M') : '' %>')" class="btn btn-xs btn-outline whitespace-nowrap">編集</button>
+                            <% end %>
                           <% else %>
-                            <button onclick="openSleepRecordModal('new', null, null, null, '<%= record[:day] %>')" class="btn btn-xs btn-outline btn-primary whitespace-nowrap">追加</button>
+                            <% if record[:day].is_a?(Date) && record[:day].to_date < Time.current.to_date %>
+                              <button onclick="openSleepRecordModal('new', null, null, null, '<%= record[:day] %>')" class="btn btn-xs btn-outline btn-primary whitespace-nowrap">追加</button>
+                            <% end %>
                           <% end %>
                         </td>
                       </tr>

--- a/app/views/history/index.html.erb
+++ b/app/views/history/index.html.erb
@@ -50,13 +50,15 @@
                         <h4 class="font-bold text-sm">
                           <%= record[:day].is_a?(Date) ? record[:day].strftime("%m-%d (%a)") : '--' %>
                         </h4>
-                        <!-- 操作系統コメントアウト
                         <% if record[:id].present? %>
-                          <button onclick="event.stopPropagation(); openSleepRecordModal('edit', <%= record[:id] %>, '<%= record[:wake_times].present? ? Time.parse(record[:wake_times].first).strftime('%Y-%m-%dT%H:%M') : '' %>', '<%= record[:bed_times].present? ? Time.parse(record[:bed_times].last).strftime('%Y-%m-%dT%H:%M') : '' %>')" class="btn btn-xs btn-outline">編集</button>
+                          <% if record[:day].is_a?(Date) && record[:day].to_date < Time.current.to_date %>
+                            <button onclick="event.stopPropagation(); openSleepRecordModal('edit', <%= record[:id] %>, '<%= record[:wake_times].present? ? Time.parse(record[:wake_times].first).strftime('%Y-%m-%dT%H:%M') : '' %>', '<%= record[:bed_times].present? ? Time.parse(record[:bed_times].last).strftime('%Y-%m-%dT%H:%M') : '' %>')" class="btn btn-xs btn-outline">編集</button>
+                          <% end %>
                         <% else %>
-                          <button onclick="event.stopPropagation(); openSleepRecordModal('new', null, null, null, '<%= record[:day] %>')" class="btn btn-xs btn-outline btn-primary">追加</button>
+                          <% if record[:day].is_a?(Date) && record[:day].to_date < Time.current.to_date %>
+                            <button onclick="event.stopPropagation(); openSleepRecordModal('new', null, null, null, '<%= record[:day] %>')" class="btn btn-xs btn-outline btn-primary">追加</button>
+                          <% end %>
                         <% end %>
-                        -->
                       </div>
                       <div class="text-xs text-base-content/70 flex gap-4">
                         <span class="flex items-center gap-1">
@@ -140,7 +142,7 @@
                   <th class="px-4 py-3 text-sm"><%= t('history.index.daily_sleep_hours') %></th>
                   <th class="px-4 py-3 text-sm"><%= t('history.index.cumulative_wake_hours') %></th>
                   <th class="px-4 py-3 text-sm"><%= t('history.index.cumulative_sleep_hours') %></th>
-                  <%# <th class="px-4 py-3 text-sm">操作</th> %>
+                  <th class="px-4 py-3 text-sm">操作</th>
                 </tr>
               </thead>
               <tbody>
@@ -183,9 +185,13 @@
                     </td>
                     <td class="px-4 py-3">
                       <% if record[:id].present? %>
-                        <button onclick="openSleepRecordModal('edit', <%= record[:id] %>, '<%= record[:wake_times].present? ? Time.parse(record[:wake_times].first).strftime('%Y-%m-%dT%H:%M') : '' %>', '<%= record[:bed_times].present? ? Time.parse(record[:bed_times].last).strftime('%Y-%m-%dT%H:%M') : '' %>')" class="btn btn-xs btn-outline whitespace-nowrap">編集</button>
+                        <% if record[:day].is_a?(Date) && record[:day].to_date < Time.current.to_date %>
+                          <button onclick="openSleepRecordModal('edit', <%= record[:id] %>, '<%= record[:wake_times].present? ? Time.parse(record[:wake_times].first).strftime('%Y-%m-%dT%H:%M') : '' %>', '<%= record[:bed_times].present? ? Time.parse(record[:bed_times].last).strftime('%Y-%m-%dT%H:%M') : '' %>')" class="btn btn-xs btn-outline whitespace-nowrap">編集</button>
+                        <% end %>
                       <% else %>
-                        <button onclick="openSleepRecordModal('new', null, null, null, '<%= record[:day] %>')" class="btn btn-xs btn-outline btn-primary whitespace-nowrap">追加</button>
+                        <% if record[:day].is_a?(Date) && record[:day].to_date < Time.current.to_date %>
+                          <button onclick="openSleepRecordModal('new', null, null, null, '<%= record[:day] %>')" class="btn btn-xs btn-outline btn-primary whitespace-nowrap">追加</button>
+                        <% end %>
                       <% end %>
                     </td>
                   </tr>

--- a/app/views/shared/_sleep_record_modal.html.erb
+++ b/app/views/shared/_sleep_record_modal.html.erb
@@ -25,6 +25,7 @@
         <div class="grid grid-cols-2 gap-3">
           <%= f.date_field :wake_date,
               class: "input input-bordered input-lg",
+              max: (Time.current - 1.day).to_date.to_s,
               required: true,
               id: "modal_wake_date" %>
           <%= f.time_field :wake_time_only,
@@ -49,6 +50,7 @@
         <div class="grid grid-cols-2 gap-3">
           <%= f.date_field :bed_date,
               class: "input input-bordered input-lg",
+              max: (Time.current - 1.day).to_date.to_s,
               id: "modal_bed_date" %>
           <%= f.time_field :bed_time_only,
               class: "input input-bordered input-lg",
@@ -112,16 +114,23 @@
         document.getElementById('modal_wake_date').value = date;
         document.getElementById('modal_wake_time_only').value = '07:00';
         updateWakeTimeHidden();
+
+        // 就寝時刻は同日の22:00を初期値として設定
+        document.getElementById('modal_bed_date').value = date;
+        document.getElementById('modal_bed_time_only').value = '22:00';
+        updateBedTimeHidden();
       } else {
         const now = new Date();
         document.getElementById('modal_wake_date').value = now.toISOString().split('T')[0];
         document.getElementById('modal_wake_time_only').value = now.toTimeString().slice(0, 5);
         updateWakeTimeHidden();
-      }
 
-      document.getElementById('modal_bed_date').value = '';
-      document.getElementById('modal_bed_time_only').value = '';
-      document.getElementById('modal_bed_time').value = '';
+        // 就寝時刻は同日の22:00を初期値として設定
+        const bedDateStr = now.toISOString().split('T')[0];
+        document.getElementById('modal_bed_date').value = bedDateStr;
+        document.getElementById('modal_bed_time_only').value = '22:00';
+        updateBedTimeHidden();
+      }
     } else if (mode === 'edit') {
       title.textContent = '<%= t('modals.sleep_record.title_edit') %>';
       form.action = `/sleep_records/${recordId}`;

--- a/app/views/shared/_sleep_record_modal.html.erb
+++ b/app/views/shared/_sleep_record_modal.html.erb
@@ -25,7 +25,6 @@
         <div class="grid grid-cols-2 gap-3">
           <%= f.date_field :wake_date,
               class: "input input-bordered input-lg",
-              max: (Time.current - 1.day).to_date.to_s,
               required: true,
               id: "modal_wake_date" %>
           <%= f.time_field :wake_time_only,
@@ -50,7 +49,6 @@
         <div class="grid grid-cols-2 gap-3">
           <%= f.date_field :bed_date,
               class: "input input-bordered input-lg",
-              max: (Time.current - 1.day).to_date.to_s,
               id: "modal_bed_date" %>
           <%= f.time_field :bed_time_only,
               class: "input input-bordered input-lg",

--- a/app/views/sleep_records/edit.html.erb
+++ b/app/views/sleep_records/edit.html.erb
@@ -18,7 +18,7 @@
             <%= f.datetime_local_field :wake_time,
                 class: "input input-bordered w-full",
                 value: @sleep_record.wake_time&.strftime("%Y-%m-%dT%H:%M"),
-                max: Time.current.strftime("%Y-%m-%dT%H:%M") %>
+                max: (Time.current - 1.day).end_of_day.strftime("%Y-%m-%dT%H:%M") %>
             <label class="label">
               <span class="label-text-alt text-base-content/60"><%= t('sleep_records.edit.future_time_note') %></span>
             </label>
@@ -29,7 +29,7 @@
             <%= f.datetime_local_field :bed_time,
                 class: "input input-bordered w-full",
                 value: @sleep_record.bed_time&.strftime("%Y-%m-%dT%H:%M"),
-                max: Time.current.strftime("%Y-%m-%dT%H:%M") %>
+                max: (Time.current - 1.day).end_of_day.strftime("%Y-%m-%dT%H:%M") %>
             <label class="label">
               <span class="label-text-alt text-base-content/60"><%= t('sleep_records.edit.future_time_note') %></span>
             </label>

--- a/app/views/sleep_records/new.html.erb
+++ b/app/views/sleep_records/new.html.erb
@@ -17,7 +17,7 @@
             <%= f.label :wake_time, t('sleep_records.new.wake_time_label'), class: "label" %>
             <%= f.datetime_local_field :wake_time,
                 class: "input input-bordered w-full",
-                max: Time.current.strftime("%Y-%m-%dT%H:%M"),
+                max: (Time.current - 1.day).end_of_day.strftime("%Y-%m-%dT%H:%M"),
                 required: true %>
             <label class="label">
               <span class="label-text-alt text-base-content/60"><%= t('sleep_records.new.future_time_note') %></span>
@@ -28,7 +28,7 @@
             <%= f.label :bed_time, t('sleep_records.new.bed_time_label'), class: "label" %>
             <%= f.datetime_local_field :bed_time,
                 class: "input input-bordered w-full",
-                max: Time.current.strftime("%Y-%m-%dT%H:%M") %>
+                max: (Time.current - 1.day).end_of_day.strftime("%Y-%m-%dT%H:%M") %>
             <label class="label">
               <span class="label-text-alt text-base-content/60"><%= t('sleep_records.new.future_time_note') %></span>
             </label>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -124,6 +124,7 @@ ja:
       wake_time_label: "起床時刻"
       bed_time_label: "就寝時刻"
       future_time_note: "※未来の時刻は設定できません"
+      cannot_edit_today_or_later: "当日以降の記録は編集できません"
       submit: "更新"
       cancel: "キャンセル"
     create:
@@ -131,6 +132,7 @@ ja:
       need_previous_bed_time: "前回の就寝時刻を先に記録してください"
       wake_time_recorded: "起床時刻を記録しました"
       wake_time_failed: "起床時刻の記録に失敗しました: %{errors}"
+      cannot_create_today_or_later: "当日以降の記録は作成できません。過去の日付で記録してください"
       record_created: "記録を作成しました"
     update:
       no_unwoken_record: "未就寝レコードがありません"


### PR DESCRIPTION
概要 ￼

対応PR：Issue #178

対応内容 ￼

- 当日以降の編集・作成をサーバーで拒否、UIでもボタン非表示 controller/views/locale ↗

- 起床／睡眠それぞれで有効日のみを母数にして平均算出 controllers ↗

- 累計生成で前レコード引き継ぎを抑制（フラグ追加） aggregator ↗

- 未来時刻の判定を日付比較に修正、複雑バリデーションを削除 model ↗

目的 ￼

- データ整合性とUI一貫性の向上

- 指標（平均・累計）のブレ低減

動作確認方法 ￼

1. 当日以降は編集／追加ボタンが表示されない

2. 当日以降の編集はリダイレクト、作成は422＋エラーメッセージ

3. 週・月の平均が有効日だけを母数に計算されること