### PR TITLE
Fix/dashboard

### DIFF
--- a/app/assets/javascripts/sleep_record_modal.js
+++ b/app/assets/javascripts/sleep_record_modal.js
@@ -119,72 +119,10 @@ function setupSleepRecordForm() {
   if (form && !form.dataset.initialized) {
     form.dataset.initialized = 'true';
 
-    form.addEventListener('submit', function(e) {
-      e.preventDefault();
-
+    form.addEventListener('submit', function() {
       // 送信前に最新の値を更新
       updateWakeTimeHidden();
       updateBedTimeHidden();
-
-      const formData = new FormData(form);
-      const url = form.action;
-      const method = form.querySelector('input[name="_method"]')?.value || 'POST';
-
-      fetch(url, {
-        method: method === 'patch' ? 'PATCH' : 'POST',
-        body: formData,
-        headers: {
-          'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content,
-          'Accept': 'application/json'
-        }
-      }).then(response => {
-        console.log('Response status:', response.status, 'OK:', response.ok);
-        return response.json().then(data => {
-          console.log('Response data:', data);
-          if (data.success) {
-            // 成功時はリダイレクト
-            console.log('Redirecting to:', data.redirect_url);
-            window.location.href = data.redirect_url || '/';
-          } else if (response.status === 422 || response.status === 400 || data.errors) {
-            // バリデーションエラー
-            const errorsDiv = document.getElementById('sleep_record_errors');
-            const errorList = document.getElementById('sleep_record_error_list');
-            errorList.innerHTML = '';
-
-            if (data.errors && Array.isArray(data.errors)) {
-              data.errors.forEach(error => {
-                const li = document.createElement('li');
-                li.textContent = error;
-                errorList.appendChild(li);
-              });
-              errorsDiv.classList.remove('hidden');
-            } else if (data.errors) {
-              errorList.innerHTML = '<li>エラーが発生しました</li>';
-              errorsDiv.classList.remove('hidden');
-              console.error('Error details:', data);
-            }
-          } else {
-            // その他のエラー
-            const errorsDiv = document.getElementById('sleep_record_errors');
-            const errorList = document.getElementById('sleep_record_error_list');
-            errorList.innerHTML = '<li>予期しないエラーが発生しました</li>';
-            errorsDiv.classList.remove('hidden');
-            console.error('Response:', response, 'Data:', data);
-          }
-        }).catch(parseError => {
-          console.error('JSON parse error:', parseError);
-          const errorsDiv = document.getElementById('sleep_record_errors');
-          const errorList = document.getElementById('sleep_record_error_list');
-          errorList.innerHTML = '<li>通信エラーが発生しました（レスポンス解析失敗）</li>';
-          errorsDiv.classList.remove('hidden');
-        });
-      }).catch(error => {
-        console.error('Fetch error:', error);
-        const errorsDiv = document.getElementById('sleep_record_errors');
-        const errorList = document.getElementById('sleep_record_error_list');
-        errorList.innerHTML = '<li>通信エラーが発生しました</li>';
-        errorsDiv.classList.remove('hidden');
-      });
     });
   }
 }

--- a/app/controllers/google_calendars_controller.rb
+++ b/app/controllers/google_calendars_controller.rb
@@ -27,9 +27,9 @@ class GoogleCalendarsController < ApplicationController
       description: params[:description],
       location: params[:location]
     )
-      redirect_to google_calendars_path, notice: "予定を作成しました"
+      redirect_to redirect_path, notice: "予定を作成しました"
     else
-      redirect_to google_calendars_path, alert: "予定の作成に失敗しました"
+      redirect_to redirect_path, alert: "予定の作成に失敗しました"
     end
   end
 
@@ -100,5 +100,14 @@ class GoogleCalendarsController < ApplicationController
 
   def parse_datetime(date_str, time_str)
     Time.zone.parse("#{date_str} #{time_str}")
+  end
+
+  def redirect_path
+    # リファラーがダッシュボードの場合はダッシュボードに戻す
+    if request.referer&.include?("dashboard")
+      dashboard_path
+    else
+      google_calendars_path
+    end
   end
 end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -3,11 +3,11 @@
   <%= t('dashboard.index.page_title') %>
 <% end %>
 
-    <div class="flex flex-col lg:flex-row gap-3 sm:gap-4 lg:gap-6 mb-6 sm:mb-8">
+    <div class="flex flex-col lg:flex-row lg:items-start gap-3 sm:gap-4 lg:gap-6 mb-6 sm:mb-8">
       <!-- 左カラム -->
-      <div class="w-full lg:flex-[7] flex flex-col gap-3 sm:gap-4 lg:gap-6">
+      <div class="w-full lg:w-auto lg:flex-[7_0_0%] flex flex-col gap-3 sm:gap-4 lg:gap-6">
         <!-- グラフ -->
-        <div class="card bg-base-100 border border-base-300">
+        <div class="card bg-base-100 border border-base-300 min-w-0">
           <div class="card-body p-4">
             <div class="flex items-center justify-between mb-4">
               <h3 class="text-2xl font-bold"><%= t('dashboard.index.activity_graph') %></h3>
@@ -21,7 +21,7 @@
         </div>
 
         <!-- 記録カード（モバイル） -->
-        <div class="lg:hidden card bg-base-100 border border-base-300">
+        <div class="lg:hidden card bg-base-100 border border-base-300 min-w-0">
           <div class="card-body p-4">
             <div class="space-y-3">
               <%= button_to I18n.t('dashboard.index.wake_record'), sleep_records_path,
@@ -41,9 +41,9 @@
         </div>
 
         <!-- 記録テーブル -->
-        <div class="card bg-base-100 border border-base-300">
+        <div class="card bg-base-100 border border-base-300 min-w-0">
           <details class="group [&_summary::-webkit-details-marker]:hidden">
-            <summary class="cursor-pointer p-4 font-bold text-xl bg-base-100 flex justify-between items-center rounded-t-lg">
+            <summary class="cursor-pointer p-4 font-bold text-xl bg-base-100 flex justify-between items-center group-open:rounded-t-lg rounded-lg">
               <%= t('dashboard.index.this_week_records') %>
               <span class="transition-transform duration-300 group-open:rotate-180">⤵︎</span>
             </summary>
@@ -245,7 +245,7 @@
       </div>
 
       <!-- 右カラム -->
-      <div class="hidden lg:flex w-full lg:flex-[3] flex-col gap-3 sm:gap-4 lg:gap-6">
+      <div class="hidden lg:flex lg:flex-[3_0_0%] flex-col gap-3 sm:gap-4 lg:gap-6">
 
         <!-- 記録カード -->
         <div class="card bg-base-100 border border-base-300">

--- a/app/views/shared/_sleep_record_modal.html.erb
+++ b/app/views/shared/_sleep_record_modal.html.erb
@@ -7,7 +7,7 @@
 
     <h2 class="text-2xl font-bold mb-6" id="sleep_record_modal_title"><%= t('modals.sleep_record.title_new') %></h2>
 
-    <%= form_with model: SleepRecord.new, id: "sleep_record_form", class: "space-y-4", data: { turbo: false } do |f| %>
+    <%= form_with model: SleepRecord.new, id: "sleep_record_form", class: "space-y-4" do |f| %>
       <div id="sleep_record_errors" class="hidden alert alert-error mb-4">
         <ul id="sleep_record_error_list"></ul>
       </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -134,11 +134,13 @@ ja:
       wake_time_failed: "起床時刻の記録に失敗しました: %{errors}"
       cannot_create_today_or_later: "当日以降の記録は作成できません。過去の日付で記録してください"
       record_created: "記録を作成しました"
+      record_failed: "記録の作成に失敗しました: %{errors}"
     update:
       no_unwoken_record: "未就寝レコードがありません"
       bed_time_recorded: "就寝時刻を記録しました"
       bed_time_failed: "就寝時刻の記録に失敗しました: %{errors}"
       record_updated: "記録を更新しました"
+      record_failed: "記録の更新に失敗しました: %{errors}"
   pages:
     common:
       dashboard: "ダッシュボード"


### PR DESCRIPTION
対応PR：Issue #202 

## 概要
ダッシュボード周りの不具合修正と改善

## 対応内容
- 睡眠記録の作成・更新後のフラッシュメッセージ表示を修正
- ダッシュボードのアコーディオン開閉時のレイアウトずれを修正
- Googleカレンダー予定作成後のリダイレクト先を改善（ダッシュボードに戻る）

## 目的
- 睡眠記録の作成・更新時に、成功/失敗の適切なフィードバックをユーザーに提供する
- アコーディオンの開閉に関わらず、ダッシュボードの7:3カラムレイアウトを維持してUIの安定性を向上させる
- ダッシュボードからGoogleカレンダー予定を作成した場合、元のページ（ダッシュボード）に戻してユーザー体験を改善する

## 動作確認方法

### 1. 睡眠記録のフラッシュメッセージ
1. ダッシュボードで過去の日付の「編集」ボタンをクリック
2. モーダルで睡眠記録を編集して「更新」ボタンをクリック
3. ページ上部に「記録を更新しました」というフラッシュメッセージが3秒間表示されることを確認

### 2. ダッシュボードのレイアウト
1. ダッシュボードを開く
2. 左カラムと右カラムの幅の比率（7:3）を確認
3. 「1週間分の記録」アコーディオンを開閉
4. 開閉に関わらず、左右カラムの比率が維持されることを確認

### 3. Googleカレンダーのリダイレクト
1. ダッシュボードを開く
2. 右カラムの「予定を追加」ボタンをクリック
3. 予定を作成して保存
4. カレンダーページではなく、ダッシュボードに戻ることを確認