### PR TITLE
feat: 睡眠記録の削除機能を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,7 @@ group :development, :test do
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
 
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
-  gem "brakeman", require: false
+  gem "brakeman", "~> 7.1.2", require: false
 
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
   gem "rubocop-rails-omakase", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.19.0)
       msgpack (~> 1.2)
-    brakeman (7.1.1)
+    brakeman (7.1.2)
       racc
     builder (3.3.0)
     capybara (3.40.0)
@@ -462,7 +462,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap
-  brakeman
+  brakeman (~> 7.1.2)
   capybara
   cssbundling-rails
   debug

--- a/app/assets/javascripts/sleep_record_modal.js
+++ b/app/assets/javascripts/sleep_record_modal.js
@@ -1,3 +1,15 @@
+// 削除処理
+window.deleteSleepRecord = function() {
+  if (!confirm('本当に削除しますか？')) {
+    return;
+  }
+
+  const deleteForm = document.getElementById('sleep_record_delete_form');
+  if (deleteForm) {
+    deleteForm.submit();
+  }
+};
+
 // 日付と時刻を結合してhiddenフィールドに設定
 function updateWakeTimeHidden() {
   const date = document.getElementById('modal_wake_date').value;
@@ -23,6 +35,9 @@ window.openSleepRecordModal = function(mode, recordId = null, wakeTime = null, b
   const title = document.getElementById('sleep_record_modal_title');
   const submitBtn = document.getElementById('sleep_record_submit_btn');
   const errorsDiv = document.getElementById('sleep_record_errors');
+  const deleteBtn = document.getElementById('sleep_record_delete_btn');
+  const deleteForm = document.getElementById('sleep_record_delete_form');
+  const footer = document.getElementById('sleep_record_modal_footer');
 
   // エラー表示をクリア
   errorsDiv.classList.add('hidden');
@@ -32,7 +47,19 @@ window.openSleepRecordModal = function(mode, recordId = null, wakeTime = null, b
     title.textContent = modal.dataset.titleNew;
     form.action = '/sleep_records';
     form.querySelector('input[name="_method"]')?.remove();
-    submitBtn.textContent = modal.dataset.labelCreate;
+    submitBtn.value = modal.dataset.labelCreate;
+
+    // 削除ボタンを非表示、フッターを右寄せ
+    if (deleteBtn) {
+      deleteBtn.classList.add('hidden');
+    }
+    if (deleteForm) {
+      deleteForm.action = '';
+    }
+    if (footer) {
+      footer.classList.remove('justify-between');
+      footer.classList.add('justify-end');
+    }
 
     // dateパラメータがある場合、起床時刻のデフォルト値を設定
     if (date) {
@@ -71,7 +98,19 @@ window.openSleepRecordModal = function(mode, recordId = null, wakeTime = null, b
     }
     methodInput.value = 'patch';
 
-    submitBtn.textContent = modal.dataset.labelUpdate;
+    submitBtn.value = modal.dataset.labelUpdate;
+
+    // 削除ボタンを表示して、削除フォームのactionを設定、フッターを左右配置
+    if (deleteBtn) {
+      deleteBtn.classList.remove('hidden');
+    }
+    if (deleteForm) {
+      deleteForm.action = `/sleep_records/${recordId}`;
+    }
+    if (footer) {
+      footer.classList.remove('justify-end');
+      footer.classList.add('justify-between');
+    }
 
     // 起床時刻を分離
     if (wakeTime) {

--- a/app/controllers/sleep_records_controller.rb
+++ b/app/controllers/sleep_records_controller.rb
@@ -1,7 +1,7 @@
 class SleepRecordsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_unwoken_record, only: [ :create ]
-  before_action :set_sleep_record, only: [ :edit, :update ]
+  before_action :set_sleep_record, only: [ :edit, :update, :destroy ]
 
   def new
     @sleep_record = current_user.sleep_records.build
@@ -40,6 +40,18 @@ class SleepRecordsController < ApplicationController
     session[:return_to] = request.referer
   end
 
+  def destroy
+    # 当日以降のレコードは削除不可
+    if @sleep_record.wake_time.to_date >= Time.current.to_date
+      return redirect_with_flash(:alert, I18n.t("sleep_records.destroy.cannot_delete_today_or_later"))
+    end
+
+    if @sleep_record.destroy
+      redirect_with_flash(:notice, I18n.t("sleep_records.destroy.record_deleted"))
+    else
+      redirect_with_flash(:alert, I18n.t("sleep_records.destroy.delete_failed"))
+    end
+  end
 
   private
 

--- a/app/views/shared/_sleep_record_modal.html.erb
+++ b/app/views/shared/_sleep_record_modal.html.erb
@@ -1,4 +1,3 @@
-<!-- 睡眠記録作成・編集モーダル -->
 <dialog id="sleep_record_modal" class="modal" data-title-new="<%= t('modals.sleep_record.title_new') %>" data-title-edit="<%= t('modals.sleep_record.title_edit') %>" data-label-create="<%= t('modals.sleep_record.create') %>" data-label-update="<%= t('modals.sleep_record.update') %>">
   <div class="modal-box max-w-2xl">
     <form method="dialog">
@@ -58,11 +57,27 @@
         <%= f.hidden_field :bed_time, id: "modal_bed_time" %>
       </div>
 
-      <div class="flex justify-end gap-2 pt-4 border-t border-base-300">
-        <button type="button" onclick="sleep_record_modal.close()" class="btn btn-outline"><%= t('modals.sleep_record.cancel') %></button>
-        <%= f.submit t('modals.sleep_record.create'), class: "btn btn-primary", id: "sleep_record_submit_btn" %>
+      <div class="flex justify-end gap-2 pt-4 border-t border-base-300" id="sleep_record_modal_footer">
+        <!-- 削除ボタン（編集時のみ表示） -->
+        <button type="button"
+                onclick="deleteSleepRecord()"
+                class="btn btn-error btn-outline hidden"
+                id="sleep_record_delete_btn">
+          <%= t('modals.sleep_record.delete') %>
+        </button>
+
+        <div class="flex gap-2">
+          <button type="button" onclick="sleep_record_modal.close()" class="btn btn-outline"><%= t('modals.sleep_record.cancel') %></button>
+          <%= f.submit t('modals.sleep_record.create'), class: "btn btn-primary", id: "sleep_record_submit_btn" %>
+        </div>
       </div>
     <% end %>
+
+    <!-- 削除フォーム -->
+    <form id="sleep_record_delete_form" method="post" style="display: none;">
+      <input type="hidden" name="_method" value="delete">
+      <input type="hidden" name="authenticity_token" value="<%= form_authenticity_token %>">
+    </form>
   </div>
   <form method="dialog" class="modal-backdrop">
     <button>close</button>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -129,6 +129,7 @@ ja:
       cancel: "キャンセル"
     create:
       already_has_unwoken_record: "すでに未就寝レコードがあります"
+      already_has_today_record: "本日の起床記録は既に存在します"
       need_previous_bed_time: "前回の就寝時刻を先に記録してください"
       wake_time_recorded: "起床時刻を記録しました"
       wake_time_failed: "起床時刻の記録に失敗しました: %{errors}"
@@ -137,10 +138,16 @@ ja:
       record_failed: "記録の作成に失敗しました: %{errors}"
     update:
       no_unwoken_record: "未就寝レコードがありません"
+      no_today_wake_record: "本日の起床記録がありません。先に起床記録をしてください"
       bed_time_recorded: "就寝時刻を記録しました"
+      bed_time_updated: "就寝時刻を更新しました"
       bed_time_failed: "就寝時刻の記録に失敗しました: %{errors}"
       record_updated: "記録を更新しました"
       record_failed: "記録の更新に失敗しました: %{errors}"
+    destroy:
+      cannot_delete_today_or_later: "当日以降の記録は削除できません"
+      record_deleted: "記録を削除しました"
+      delete_failed: "記録の削除に失敗しました"
   pages:
     common:
       dashboard: "ダッシュボード"
@@ -183,6 +190,7 @@ ja:
       cancel: "キャンセル"
       create: "作成"
       update: "更新"
+      delete: "削除"
     mobile_calendar:
       close: "✕"
       today_schedule: "今日の予定"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,7 @@ Rails.application.routes.draw do
   end
 
 
-  resources :sleep_records, only: [ :new, :create, :update, :edit ]
+  resources :sleep_records, only: [ :new, :create, :update, :edit, :destroy ]
 
   # Google Calendar
   resources :google_calendars, only: [ :index, :create, :update, :destroy ] do


### PR DESCRIPTION
## 概要
  対応PR：Issue #207 

  睡眠記録の削除機能を実装、編集モーダル内から過去の記録を削除できる

  ## 対応内容
  - 睡眠記録の削除機能（`SleepRecordsController#destroy`）を実装
  - 編集モーダル内に削除ボタンを追加
  - 削除確認ダイアログの実装
  - 当日以降のレコード削除を制限
  - 削除関連の日本語翻訳を追加

  ## 目的
  - 誤って作成した記録や重複データを削除できるようにする
  - 同日に複数の起床・就寝記録を作成してしまった場合に対処できるようにする
  - データの整合性を保ちながら、ユーザーが記録を管理できる機能を提供する

  ## 動作確認方法
  1. ダッシュボードで過去の記録の「編集」ボタンをクリック
  2. モーダル左下に赤い「削除」ボタンが表示されることを確認
  3. 削除ボタンをクリック
  4. 「本当に削除しますか？」の確認ダイアログが表示されることを確認
  5. OKをクリック
  6. 「記録を削除しました」のフラッシュメッセージが表示される
  7. レコードが削除されていることを確認

  ### 例外
  1. 当日のレコードを編集（テストデータ作成が必要）
  2. 削除ボタンをクリック
  3. 「当日以降の記録は削除できません」のエラーメッセージが表示されることを確認

  ### 新規作成時
  1. 「追加」ボタンから新規作成モーダルを開く
  2. 削除ボタンが表示されないことを確認
  3. `[キャンセル] [作成]`が右寄せで表示されることを確認
---

  ## 備考

  ### 技術的な実装
  - モーダル内に既存フォームがあるため、削除用フォームはモーダル外に配置
  - `button_to`ではなく通常の`<button>`とJavaScriptでフォーム送信を実装
  - モードに応じてレイアウトを動的に切り替え`justify-end`  `justify-between`

  ### セキュリティ
  - CSRF対策トークンを削除フォームに含める
  - 当日以降のレコードは削除不可（データ整合性の保護）

  ### 変更ファイル
  - `app/controllers/sleep_records_controller.rb`
  - `app/views/shared/_sleep_record_modal.html.erb`
  - `app/assets/javascripts/sleep_record_modal.js`
  - `config/routes.rb`
  - `config/locales/ja.yml`

  ### 今後の改善案
  - 削除時のアニメーション追加
  - 削除の取り消し機能（Undo）
  - 一括削除機能