### PR TITLE
refactor: ビューのpartial化とスタイル統一

### DIFF
--- a/app/assets/javascripts/modal_helper.js
+++ b/app/assets/javascripts/modal_helper.js
@@ -1,0 +1,41 @@
+window.toggleModalElement = function(element, show, ...classesToToggle) {
+  if (!element) return;
+
+  if (show) {
+    element.classList.remove('hidden');
+    classesToToggle.forEach(cls => element.classList.add(cls));
+  } else {
+    element.classList.add('hidden');
+    classesToToggle.forEach(cls => element.classList.remove(cls));
+  }
+};
+
+window.setModalFooterLayout = function(footer, hasDelete) {
+  if (!footer) return;
+
+  footer.classList.toggle('justify-between', hasDelete);
+  footer.classList.toggle('justify-end', !hasDelete);
+};
+
+window.setFormField = function(fieldId, value) {
+  const field = document.getElementById(fieldId);
+  if (field) {
+    field.value = value || '';
+  }
+};
+
+window.setFormFields = function(fields) {
+  Object.entries(fields).forEach(([fieldId, value]) => {
+    window.setFormField(fieldId, value);
+  });
+};
+
+window.setModalTitle = function(modalId, title) {
+  const modal = document.getElementById(modalId);
+  if (!modal) return;
+
+  const titleElement = modal.querySelector('h3, h2');
+  if (titleElement) {
+    titleElement.textContent = title;
+  }
+};

--- a/app/assets/javascripts/sleep_record_modal.js
+++ b/app/assets/javascripts/sleep_record_modal.js
@@ -49,17 +49,12 @@ window.openSleepRecordModal = function(mode, recordId = null, wakeTime = null, b
     form.querySelector('input[name="_method"]')?.remove();
     submitBtn.value = modal.dataset.labelCreate;
 
-    // 削除ボタンを非表示、フッターを右寄せ
-    if (deleteBtn) {
-      deleteBtn.classList.add('hidden');
-    }
+    // 削除ボタンを非表示、フッターを右寄せ（ヘルパー関数を使用）
+    window.toggleModalElement(deleteBtn, false);
     if (deleteForm) {
       deleteForm.action = '';
     }
-    if (footer) {
-      footer.classList.remove('justify-between');
-      footer.classList.add('justify-end');
-    }
+    window.setModalFooterLayout(footer, false);
 
     // dateパラメータがある場合、起床時刻のデフォルト値を設定
     if (date) {
@@ -100,17 +95,12 @@ window.openSleepRecordModal = function(mode, recordId = null, wakeTime = null, b
 
     submitBtn.value = modal.dataset.labelUpdate;
 
-    // 削除ボタンを表示して、削除フォームのactionを設定、フッターを左右配置
-    if (deleteBtn) {
-      deleteBtn.classList.remove('hidden');
-    }
+    // 削除ボタンを表示して、削除フォームのactionを設定、フッターを左右配置（ヘルパー関数を使用）
+    window.toggleModalElement(deleteBtn, true);
     if (deleteForm) {
       deleteForm.action = `/sleep_records/${recordId}`;
     }
-    if (footer) {
-      footer.classList.remove('justify-end');
-      footer.classList.add('justify-between');
-    }
+    window.setModalFooterLayout(footer, true);
 
     // 起床時刻を分離
     if (wakeTime) {

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -67,3 +67,68 @@
 .navbar-menu {
   background-color: oklch(24.353% 0 0) !important;
 }
+
+/* カスタムコンポーネントクラス */
+@layer components {
+  /* アイコン関連 */
+  .icon-standard {
+    @apply h-5 w-5 text-base-content/70 flex-shrink-0;
+  }
+
+  .icon-small {
+    @apply h-4 w-4;
+  }
+
+  .icon-tiny {
+    @apply h-3 w-3;
+  }
+
+  /* テキスト関連 */
+  .text-label {
+    @apply text-xs text-base-content/70;
+  }
+
+  .text-label-light {
+    @apply text-xs text-base-content/60;
+  }
+
+  .text-section-title {
+    @apply text-2xl font-bold mb-4;
+  }
+
+  .text-card-title {
+    @apply text-lg font-bold;
+  }
+
+  /* レイアウト・スペーシング関連 */
+  .section-spacer {
+    @apply mb-8;
+  }
+
+  .element-spacer {
+    @apply mb-4;
+  }
+
+  .event-info-item {
+    @apply flex items-start gap-2;
+  }
+
+  /* フォーム関連 */
+  .form-field {
+    @apply form-control mb-4;
+  }
+
+  .input-standard {
+    @apply input input-bordered w-full;
+  }
+
+  /* ボタン関連 */
+  .btn-modal-close {
+    @apply btn btn-sm btn-circle btn-ghost absolute right-2 top-2;
+  }
+
+  /* モーダル関連 */
+  .modal-container {
+    @apply modal-box max-w-2xl;
+  }
+}

--- a/app/javascript/charts/sleep_chart.js
+++ b/app/javascript/charts/sleep_chart.js
@@ -3,99 +3,117 @@ import Highcharts from "highcharts";
 
 window.Highcharts = Highcharts;
 
+const CHART_CONFIG = {
+  colors: {
+    primary: "rgb(72, 125, 0)",
+    axis: "#cdcdcd",
+  },
+  marker: {
+    radius: 4.5,
+    hoverRadiusPlus: 1.5,
+  },
+  line: {
+    width: 2.5,
+    fillOpacity: 0.25,
+  },
+  tickIntervals: ["00:00", "06:00", "12:00", "18:00"],
+};
+
+const WEEKDAYS = ["日", "月", "火", "水", "木", "金", "土"];
+
+const formatDate = (timestamp) => {
+  const date = new Date(timestamp);
+  if (isNaN(date)) return { m: "", d: "", w: "", hh: "", mm: "" };
+
+  return {
+    m: (date.getMonth() + 1).toString().padStart(2, "0"),
+    d: date.getDate().toString().padStart(2, "0"),
+    w: WEEKDAYS[date.getDay()],
+    hh: date.getHours().toString().padStart(2, "0"),
+    mm: date.getMinutes().toString().padStart(2, "0"),
+  };
+};
+
+const createTooltipFormatter = () => {
+  return function () {
+    const { m, d, w, hh, mm } = formatDate(this.x);
+    const value = typeof this.y === "number" ? this.y.toFixed(2) : this.y;
+    return `${m}-${d}（${w}） ${hh}:${mm}<br>累計: ${value}h`;
+  };
+};
+
+const createAxisLabelFormatter = () => {
+  return function () {
+    const { m, d, w, hh, mm } = formatDate(this.value);
+    if (!m) return "";
+
+    const timeStr = `${hh}:${mm}`;
+    if (!CHART_CONFIG.tickIntervals.includes(timeStr)) return "";
+
+    return timeStr === "00:00" ? `${m}/${d}(${w})` : timeStr;
+  };
+};
+
+const getChartOptions = () => ({
+  xtitle: "時間",
+  ytitle: "累計活動時間（h）",
+  discrete: false,
+  library: {
+    chart: {
+      backgroundColor: "transparent",
+      type: "area",
+      zoomType: "x",
+      scrollablePlotArea: { minWidth: 400, scrollPositionX: 1 },
+    },
+    accessibility: { enabled: false },
+    colors: [CHART_CONFIG.colors.primary],
+    tooltip: { formatter: createTooltipFormatter() },
+    plotOptions: {
+      area: {
+        marker: {
+          enabled: true,
+          radius: CHART_CONFIG.marker.radius,
+          symbol: "circle",
+          states: {
+            hover: { radiusPlus: CHART_CONFIG.marker.hoverRadiusPlus },
+          },
+        },
+        lineWidth: CHART_CONFIG.line.width,
+        fillOpacity: CHART_CONFIG.line.fillOpacity,
+        threshold: 0,
+        negativeFillColor: "rgba(0,0,0,0)",
+      },
+    },
+    xAxis: {
+      lineColor: CHART_CONFIG.colors.axis,
+      tickColor: CHART_CONFIG.colors.axis,
+      labels: {
+        style: { color: CHART_CONFIG.colors.axis },
+        formatter: createAxisLabelFormatter(),
+      },
+      title: { style: { color: CHART_CONFIG.colors.axis, fontWeight: "bold" } },
+    },
+    yAxis: {
+      lineColor: CHART_CONFIG.colors.axis,
+      tickColor: CHART_CONFIG.colors.axis,
+      labels: { style: { color: CHART_CONFIG.colors.axis } },
+      title: { style: { color: CHART_CONFIG.colors.axis, fontWeight: "bold" } },
+      gridLineColor: CHART_CONFIG.colors.axis,
+    },
+  },
+});
+
 document.addEventListener("turbo:load", () => {
   const chartElements = Array.from(
     document.querySelectorAll('[id^="sleep-chart"]')
   );
+
   chartElements.forEach((chartElement) => {
     if (!chartElement.dataset.series) return;
 
-    // 既存チャートをクリア（Turbo再読み込み時の重複防止）
     chartElement.innerHTML = "";
 
     const seriesData = JSON.parse(chartElement.dataset.series);
-
-    new Chartkick.LineChart(chartElement, seriesData, {
-      xtitle: "時間",
-      ytitle: "累計活動時間（h）",
-      discrete: false,
-      library: {
-        chart: {
-          backgroundColor: "transparent",
-          type: "area",
-          zoomType: "x",
-          scrollablePlotArea: { minWidth: 400, scrollPositionX: 1 },
-        },
-        accessibility: { enabled: false },
-        colors: ["rgb(72, 125, 0)"],
-        tooltip: {
-          formatter: function () {
-            const date = new Date(this.x);
-            const m = (date.getMonth() + 1).toString().padStart(2, "0");
-            const d = date.getDate().toString().padStart(2, "0");
-            const weekdays = ["日", "月", "火", "水", "木", "金", "土"];
-            const w = weekdays[date.getDay()];
-            const hh = date.getHours().toString().padStart(2, "0");
-            const mm = date.getMinutes().toString().padStart(2, "0");
-            const value =
-              typeof this.y === "number" ? this.y.toFixed(2) : this.y;
-            return `${m}-${d}（${w}） ${hh}:${mm}<br>累計: ${value}h`;
-          },
-        },
-        plotOptions: {
-          area: {
-            marker: {
-              enabled: true,
-              radius: 4.5,
-              symbol: "circle",
-              states: {
-                hover: { radiusPlus: 1.5 },
-              },
-            },
-            lineWidth: 2.5,
-            fillOpacity: 0.25,
-            threshold: 0,
-            negativeFillColor: "rgba(0,0,0,0)",
-          },
-        },
-        xAxis: {
-          lineColor: "#cdcdcd",
-          tickColor: "#cdcdcd",
-          labels: {
-            style: { color: "#cdcdcd" },
-            formatter: function () {
-              const date = new Date(this.value);
-              if (isNaN(date)) return "";
-              const m = (date.getMonth() + 1).toString().padStart(2, "0");
-              const d = date.getDate().toString().padStart(2, "0");
-              const weekdays = ["日", "月", "火", "水", "木", "金", "土"];
-              const w = weekdays[date.getDay()];
-              const hh = date.getHours().toString().padStart(2, "0");
-              const mm = date.getMinutes().toString().padStart(2, "0");
-              const timeStr = `${hh}:${mm}`;
-
-              // 6時間おきに目盛り
-              if (!["00:00", "06:00", "12:00", "18:00"].includes(timeStr))
-                return "";
-
-              // 00:00 のときだけ日付も表示
-              if (timeStr === "00:00") {
-                return `${m}/${d}(${w})`;
-              } else {
-                return timeStr;
-              }
-            },
-          },
-          title: { style: { color: "#cdcdcd", fontWeight: "bold" } },
-        },
-        yAxis: {
-          lineColor: "#cdcdcd",
-          tickColor: "#cdcdcd",
-          labels: { style: { color: "#cdcdcd" } },
-          title: { style: { color: "#cdcdcd", fontWeight: "bold" } },
-          gridLineColor: "#cdcdcd",
-        },
-      },
-    });
+    new Chartkick.LineChart(chartElement, seriesData, getChartOptions());
   });
 });

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,4 +1,3 @@
-<%# encoding: utf-8 %>
 <% content_for :page_title do %>
   <%= t('dashboard.index.page_title') %>
 <% end %>
@@ -7,240 +6,49 @@
       <!-- 左カラム -->
       <div class="w-full lg:w-auto lg:flex-[7_0_0%] flex flex-col gap-3 sm:gap-4 lg:gap-6">
         <!-- グラフ -->
-        <div class="card bg-base-100 border border-base-300 min-w-0">
-          <div class="card-body p-4">
-            <div class="flex items-center justify-between mb-4">
-              <h3 class="text-2xl font-bold"><%= t('dashboard.index.activity_graph') %></h3>
-              <span class="badge badge-outline"><%= t('dashboard.index.week') %></span>
-            </div>
-            <div id="sleep-chart"
-              data-series='<%= @series.to_json.html_safe %>'
-              class="h-[250px] sm:h-[300px] lg:h-[350px]">
-            </div>
+        <%= render 'shared/card', class: 'min-w-0' do %>
+          <div class="flex items-center justify-between mb-4">
+            <h3 class="text-2xl font-bold"><%= t('dashboard.index.activity_graph') %></h3>
+            <span class="badge badge-outline"><%= t('dashboard.index.week') %></span>
           </div>
-        </div>
+          <div id="sleep-chart"
+            data-series='<%= @series.to_json.html_safe %>'
+            class="h-[250px] sm:h-[300px] lg:h-[350px]">
+          </div>
+        <% end %>
 
         <!-- 記録カード（モバイル） -->
-        <div class="lg:hidden card bg-base-100 border border-base-300 min-w-0">
-          <div class="card-body p-4">
-            <div class="space-y-3">
-              <%= button_to I18n.t('dashboard.index.wake_record'), sleep_records_path,
-                  method: :post,
-                  class: "btn btn-primary btn-lg w-full #{'btn-disabled' if @unwoken_record.present?}",
-                  disabled: @unwoken_record.present?,
-                  data: { test: 'mobile-wake-button' } %>
-              <%= button_to I18n.t('dashboard.index.bed_record'),
-                  (@unwoken_record ? sleep_record_path(@unwoken_record) : "#"),
-                  method: :patch,
-                  params: { record_type: 'bed_time' },
-                  class: "btn btn-secondary btn-lg w-full #{'btn-disabled' if @unwoken_record.nil?}",
-                  disabled: @unwoken_record.nil?,
-                  data: { test: 'mobile-bed-button' } %>
-            </div>
+        <%= render 'shared/card', class: 'lg:hidden min-w-0' do %>
+          <div class="space-y-3">
+            <%= button_to I18n.t('dashboard.index.wake_record'), record_wake_sleep_records_path,
+                method: :post,
+                class: "btn btn-primary btn-lg w-full #{'btn-disabled' if @unwoken_record.present?}",
+                disabled: @unwoken_record.present?,
+                data: { test: 'mobile-wake-button' } %>
+            <%= button_to I18n.t('dashboard.index.bed_record'),
+                (@unwoken_record ? record_bed_sleep_record_path(@unwoken_record) : "#"),
+                method: :patch,
+                class: "btn btn-secondary btn-lg w-full #{'btn-disabled' if @unwoken_record.nil?}",
+                disabled: @unwoken_record.nil?,
+                data: { test: 'mobile-bed-button' } %>
           </div>
-        </div>
+        <% end %>
 
         <!-- 記録テーブル -->
-        <div class="card bg-base-100 border border-base-300 min-w-0">
-          <details class="group [&_summary::-webkit-details-marker]:hidden">
-            <summary class="cursor-pointer p-4 font-bold text-xl bg-base-100 flex justify-between items-center group-open:rounded-t-lg rounded-lg">
-              <%= t('dashboard.index.this_week_records') %>
-              <span class="transition-transform duration-300 group-open:rotate-180">⤵︎</span>
-            </summary>
-            <div class="p-4">
-              <!-- モバイル用カード表示 -->
-              <div class="md:hidden space-y-2">
-                <% @weekly_records.each_with_index do |record, idx| %>
-                  <div class="card bg-base-100 border border-base-300 shadow-sm">
-                    <details class="group">
-                      <summary class="cursor-pointer p-3 flex justify-between items-center list-none">
-                        <div class="flex-1">
-                          <div class="flex items-center gap-3 mb-1">
-                            <h4 class="font-bold text-sm">
-                              <%= record[:day].is_a?(Date) ? record[:day].strftime("%m-%d (%a)") : '--' %>
-                            </h4>
-                            <% if record[:id].present? %>
-                              <% if record[:day].is_a?(Date) && record[:day].to_date < Time.current.to_date %>
-                                <button onclick="event.stopPropagation(); openSleepRecordModal('edit', <%= record[:id] %>, '<%= record[:wake_times].present? ? Time.parse(record[:wake_times].first).strftime('%Y-%m-%dT%H:%M') : '' %>', '<%= record[:bed_times].present? ? Time.parse(record[:bed_times].last).strftime('%Y-%m-%dT%H:%M') : '' %>')" class="btn btn-xs btn-outline">編集</button>
-                              <% end %>
-                            <% else %>
-                              <% if record[:day].is_a?(Date) && record[:day].to_date < Time.current.to_date %>
-                                <button onclick="event.stopPropagation(); openSleepRecordModal('new', null, null, null, '<%= record[:day] %>')" class="btn btn-xs btn-outline btn-primary">追加</button>
-                              <% end %>
-                            <% end %>
-                          </div>
-                          <div class="text-xs text-base-content/70 flex gap-4">
-                            <span class="flex items-center gap-1">
-                              <i class="ph-fill ph-sun text-warning"></i>
-                              <% if record[:wake_times].present? %>
-                                <%= Time.parse(record[:wake_times].first).strftime("%H:%M") %>
-                              <% else %>
-                                -
-                              <% end %>
-                            </span>
-                            <span class="flex items-center gap-1">
-                              <i class="ph-fill ph-moon text-info"></i>
-                              <% if record[:bed_times].present? %>
-                                <%= Time.parse(record[:bed_times].last).strftime("%H:%M") %>
-                              <% else %>
-                                -
-                              <% end %>
-                            </span>
-                          </div>
-                        </div>
-                        <span class="transition-transform duration-300 group-open:rotate-180 text-base-content/50">▼</span>
-                      </summary>
-
-                      <div class="px-3 pb-3 pt-2 border-t border-base-300">
-                        <div class="grid grid-cols-2 gap-3 text-sm">
-                          <div>
-                            <div class="text-xs text-base-content/70 mb-1"><%= t('dashboard.index.wake_time') %></div>
-                            <% if record[:wake_times].present? %>
-                              <% record[:wake_times].each do |time| %>
-                                <span class="badge badge-success badge-sm mb-1 text-xs">
-                                  <%= Time.parse(time).strftime("%H:%M") %>
-                                </span>
-                              <% end %>
-                            <% else %>
-                              <span class="text-base-content/40">-</span>
-                            <% end %>
-                          </div>
-
-                          <div>
-                            <div class="text-xs text-base-content/70 mb-1"><%= t('dashboard.index.bed_time') %></div>
-                            <% if record[:bed_times].present? %>
-                              <% record[:bed_times].each do |time| %>
-                                <span class="badge badge-secondary badge-sm mb-1 text-xs">
-                                  <%= Time.parse(time).strftime("%H:%M") %>
-                                </span>
-                              <% end %>
-                            <% else %>
-                              <span class="text-base-content/40">-</span>
-                            <% end %>
-                          </div>
-
-                          <div>
-                            <div class="text-xs text-base-content/70 mb-1"><%= t('dashboard.index.cumulative_wake_hours') %></div>
-                            <div class="text-accent text-sm font-semibold">
-                              <%= record[:cumulative_wake_hours] || '-' %>
-                            </div>
-                          </div>
-
-                          <div>
-                            <div class="text-xs text-base-content/70 mb-1"><%= t('dashboard.index.cumulative_sleep_hours') %></div>
-                            <div class="text-info text-sm font-semibold">
-                              <%= record[:cumulative_sleep_hours] || '-' %>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </details>
-                  </div>
-                <% end %>
-              </div>
-
-              <!-- デスクトップ用テーブル表示 -->
-              <div class="hidden md:block overflow-x-auto">
-                <table class="table table-zebra w-full border-t border-base-300 text-sm">
-                  <thead class="bg-base-200">
-                    <tr>
-                      <th class="px-4 py-3 text-sm font-semibold text-base-content/70"><%= t('dashboard.index.date') %></th>
-                      <th class="px-4 py-3 text-sm font-semibold text-base-content/70"><%= t('dashboard.index.wake_time') %></th>
-                      <th class="px-4 py-3 text-sm font-semibold text-base-content/70"><%= t('dashboard.index.bed_time') %></th>
-                      <th class="px-4 py-3 text-sm font-semibold text-base-content/70"><%= t('dashboard.index.daily_wake_hours') %></th>
-                      <th class="px-4 py-3 text-sm font-semibold text-base-content/70"><%= t('dashboard.index.daily_sleep_hours') %></th>
-                      <th class="px-4 py-3 text-sm font-semibold text-base-content/70"><%= t('dashboard.index.cumulative_wake_hours') %></th>
-                      <th class="px-4 py-3 text-sm font-semibold text-base-content/70"><%= t('dashboard.index.cumulative_sleep_hours') %></th>
-                      <th class="px-4 py-3 text-sm font-semibold text-base-content/70">操作</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <% @weekly_records.each_with_index do |record, idx| %>
-                      <tr class="hover">
-                        <td class="px-4 py-3 whitespace-nowrap">
-                          <%= record[:day].is_a?(Date) ? record[:day].strftime("%m-%d (%a)") : '--' %>
-                        </td>
-                        <td class="px-4 py-3">
-                          <% if record[:wake_times].present? %>
-                            <% record[:wake_times].each do |time| %>
-                              <span class="badge badge-success badge-sm mb-1 text-xs">
-                                <%= Time.parse(time).strftime("%m/%d_%H:%M") %>
-                              </span>
-                            <% end %>
-                          <% else %>
-                            <span class="text-base-content/40">-</span>
-                          <% end %>
-                        </td>
-                        <td class="px-4 py-3">
-                          <% if record[:bed_times].present? %>
-                            <% record[:bed_times].each do |time| %>
-                              <span class="badge badge-secondary badge-sm mb-1 text-xs">
-                                <%= Time.parse(time).strftime("%m/%d_%H:%M") %>
-                              </span>
-                            <% end %>
-                          <% else %>
-                            <span class="text-base-content/40">-</span>
-                          <% end %>
-                        </td>
-                        <td class="px-4 py-3 text-accent font-semibold">
-                          <%= record[:daily_wake_hours] ? sprintf("%.2f", record[:daily_wake_hours]) : '-' %>
-                        </td>
-                        <td class="px-4 py-3 text-info font-semibold">
-                          <%= record[:daily_sleep_hours] ? sprintf("%.2f", record[:daily_sleep_hours]) : '-' %>
-                        </td>
-                        <td class="px-4 py-3 text-accent text-sm font-semibold">
-                          <%= record[:cumulative_wake_hours] || '-' %>
-                        </td>
-                        <td class="px-4 py-3 text-info text-sm font-semibold">
-                          <%= record[:cumulative_sleep_hours] || '-' %>
-                        </td>
-                        <td class="px-4 py-3">
-                          <% if record[:id].present? %>
-                            <% if record[:day].is_a?(Date) && record[:day].to_date < Time.current.to_date %>
-                              <button onclick="openSleepRecordModal('edit', <%= record[:id] %>, '<%= record[:wake_times].present? ? Time.parse(record[:wake_times].first).strftime('%Y-%m-%dT%H:%M') : '' %>', '<%= record[:bed_times].present? ? Time.parse(record[:bed_times].last).strftime('%Y-%m-%dT%H:%M') : '' %>')" class="btn btn-xs btn-outline whitespace-nowrap">編集</button>
-                            <% end %>
-                          <% else %>
-                            <% if record[:day].is_a?(Date) && record[:day].to_date < Time.current.to_date %>
-                              <button onclick="openSleepRecordModal('new', null, null, null, '<%= record[:day] %>')" class="btn btn-xs btn-outline btn-primary whitespace-nowrap">追加</button>
-                            <% end %>
-                          <% end %>
-                        </td>
-                      </tr>
-                    <% end %>
-                  </tbody>
-                </table>
-              </div>
-            </div>
-          </details>
-        </div>
+        <%= render 'shared/sleep_records_table',
+            records: @weekly_records,
+            title: t('dashboard.index.this_week_records') %>
 
         <!-- 統計 -->
-        <div class="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4 lg:gap-6">
-          <div class="card bg-base-100 border border-base-300 text-center p-3 sm:p-4">
-            <div class="text-[10px] sm:text-xs text-base-content/70 mb-1 sm:mb-2 leading-tight"><%= t('dashboard.index.weekly_average_wake_hours') %></div>
-            <div class="text-lg sm:text-xl lg:text-2xl font-bold text-success">
-              <%= @weekly_average_wake_hours ? sprintf("%.2f", @weekly_average_wake_hours) : '-' %>h
-            </div>
-          </div>
-          <div class="card bg-base-100 border border-base-300 text-center p-3 sm:p-4">
-            <div class="text-[10px] sm:text-xs text-base-content/70 mb-1 sm:mb-2 leading-tight"><%= t('dashboard.index.weekly_average_sleep_hours') %></div>
-            <div class="text-lg sm:text-xl lg:text-2xl font-bold text-info">
-              <%= @weekly_average_sleep_hours ? sprintf("%.2f", @weekly_average_sleep_hours) : '-' %>h
-            </div>
-          </div>
-          <div class="card bg-base-100 border border-base-300 text-center p-3 sm:p-4">
-            <div class="text-[10px] sm:text-xs text-base-content/70 mb-1 sm:mb-2 leading-tight"><%= t('dashboard.index.weekly_average_wake_time') %></div>
-            <div class="text-lg sm:text-xl lg:text-2xl font-bold text-primary">
-              <%= @weekly_average_wake_time || "--:--" %>
-            </div>
-          </div>
-          <div class="card bg-base-100 border border-base-300 text-center p-3 sm:p-4">
-            <div class="text-[10px] sm:text-xs text-base-content/70 mb-1 sm:mb-2 leading-tight"><%= t('dashboard.index.weekly_average_bed_time') %></div>
-            <div class="text-lg sm:text-xl lg:text-2xl font-bold text-secondary">
-              <%= @weekly_average_bed_time || "--:--" %>
-            </div>
-          </div>
-        </div>
+        <%= render 'shared/sleep_stats_cards',
+            average_wake_hours: @weekly_average_wake_hours,
+            average_sleep_hours: @weekly_average_sleep_hours,
+            average_wake_time: @weekly_average_wake_time,
+            average_bed_time: @weekly_average_bed_time,
+            average_wake_hours_label: t('dashboard.index.weekly_average_wake_hours'),
+            average_sleep_hours_label: t('dashboard.index.weekly_average_sleep_hours'),
+            average_wake_time_label: t('dashboard.index.weekly_average_wake_time'),
+            average_bed_time_label: t('dashboard.index.weekly_average_bed_time') %>
 
       </div>
 
@@ -248,30 +56,26 @@
       <div class="hidden lg:flex lg:flex-[3_0_0%] flex-col gap-3 sm:gap-4 lg:gap-6">
 
         <!-- 記録カード -->
-        <div class="card bg-base-100 border border-base-300">
-          <div class="card-body p-4">
-            <div class="space-y-3">
-              <%= button_to I18n.t('dashboard.index.wake_record'), sleep_records_path,
-                  method: :post,
-                  class: "btn btn-primary btn-lg w-full #{'btn-disabled' if @unwoken_record.present?}",
-                  disabled: @unwoken_record.present?,
-                  data: { test: 'desktop-wake-button' } %>
-              <%= button_to I18n.t('dashboard.index.bed_record'),
-                  (@unwoken_record ? sleep_record_path(@unwoken_record) : "#"),
-                  method: :patch,
-                  params: { record_type: 'bed_time' },
-                  class: "btn btn-secondary btn-lg w-full #{'btn-disabled' if @unwoken_record.nil?}",
-                  disabled: @unwoken_record.nil?,
-                  data: { test: 'desktop-bed-button' } %>
-            </div>
+        <%= render 'shared/card' do %>
+          <div class="space-y-3">
+            <%= button_to I18n.t('dashboard.index.wake_record'), record_wake_sleep_records_path,
+                method: :post,
+                class: "btn btn-primary btn-lg w-full #{'btn-disabled' if @unwoken_record.present?}",
+                disabled: @unwoken_record.present?,
+                data: { test: 'desktop-wake-button' } %>
+            <%= button_to I18n.t('dashboard.index.bed_record'),
+                (@unwoken_record ? record_bed_sleep_record_path(@unwoken_record) : "#"),
+                method: :patch,
+                class: "btn btn-secondary btn-lg w-full #{'btn-disabled' if @unwoken_record.nil?}",
+                disabled: @unwoken_record.nil?,
+                data: { test: 'desktop-bed-button' } %>
           </div>
-        </div>
+        <% end %>
 
         <!-- Googleカレンダー連携 -->
         <% if ENV["GOOGLE_CLIENT_ID"].present? && ENV["GOOGLE_CLIENT_SECRET"].present? %>
           <% if current_user&.google_authenticated? %>
-            <div class="card bg-base-100 border border-base-300">
-            <div class="card-body p-4">
+            <%= render 'shared/card' do %>
               <div class="flex items-center justify-between mb-3">
                 <h3 class="text-lg font-bold">今日の予定</h3>
                 <% if @today_events.present? %>
@@ -285,9 +89,7 @@
                     <div class="p-2 rounded hover:bg-base-200 transition-colors cursor-pointer" onclick="event_modal_<%= index %>.showModal()">
                       <div class="flex items-start gap-2">
                         <div class="flex-shrink-0 mt-0.5">
-                          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-                          </svg>
+                          <%= render 'shared/icon', type: 'calendar', size: 4, color: 'primary', flex_shrink: false %>
                         </div>
                         <div class="flex-1 min-w-0">
                           <p class="text-sm font-medium"><%= event.summary || "(タイトルなし)" %></p>
@@ -317,56 +119,7 @@
                           <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
                         </form>
                         <h3 class="font-bold text-lg mb-4"><%= event.summary || "(タイトルなし)" %></h3>
-
-                        <div class="space-y-3">
-                          <% if event.start.date_time %>
-                            <div class="flex items-start gap-2">
-                              <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-base-content/70 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-                              </svg>
-                              <div>
-                                <p class="text-sm">
-                                  <%= event.start.date_time.in_time_zone("Asia/Tokyo").strftime("%Y年%m月%d日 %H:%M") %>
-                                  <% if event.end.date_time %>
-                                    - <%= event.end.date_time.in_time_zone("Asia/Tokyo").strftime("%H:%M") %>
-                                  <% end %>
-                                </p>
-                              </div>
-                            </div>
-                          <% elsif event.start.date %>
-                            <div class="flex items-start gap-2">
-                              <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-base-content/70 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-                              </svg>
-                              <p class="text-sm">終日</p>
-                            </div>
-                          <% end %>
-
-                          <% if event.location.present? %>
-                            <div class="flex items-start gap-2">
-                              <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-base-content/70 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
-                              </svg>
-                              <p class="text-sm"><%= event.location %></p>
-                            </div>
-                          <% end %>
-
-                          <% if event.description.present? %>
-                            <div class="flex items-start gap-2">
-                              <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-base-content/70 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h7" />
-                              </svg>
-                              <p class="text-sm whitespace-pre-wrap"><%= event.description %></p>
-                            </div>
-                          <% end %>
-
-                          <% if event.respond_to?(:calendar_summary) && event.calendar_summary.present? %>
-                            <div class="pt-2 border-t border-base-300">
-                              <span class="badge badge-sm"><%= event.calendar_summary %></span>
-                            </div>
-                          <% end %>
-                        </div>
+                        <%= render 'shared/event_details', event: event %>
                       </div>
                       <form method="dialog" class="modal-backdrop">
                         <button>close</button>
@@ -382,22 +135,19 @@
 
               <div class="pt-3 border-t border-base-300">
                 <button onclick="new_event_modal.showModal()" class="btn btn-primary btn-sm w-full">
-                  <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
-                  </svg>
+                  <%= render 'shared/icon', type: 'plus', size: 4, flex_shrink: false %>
                   予定を追加
                 </button>
               </div>
-            </div>
-          </div>
+            <% end %>
           <% else %>
-            <div class="card bg-base-100 border border-base-300">
-              <div class="card-body p-4 text-center">
+            <%= render 'shared/card' do %>
+              <div class="text-center">
                 <h3 class="text-lg font-bold mb-2">Googleカレンダーと連携</h3>
                 <p class="text-sm text-base-content/70 mb-4">カレンダーと連携して予定を表示しましょう</p>
                 <%= button_to "Googleカレンダーと連携", user_google_oauth2_omniauth_authorize_path, method: :post, class: "btn btn-primary btn-sm", data: { turbo: false } %>
               </div>
-            </div>
+            <% end %>
           <% end %>
         <% end %>
       </div>

--- a/app/views/history/index.html.erb
+++ b/app/views/history/index.html.erb
@@ -2,231 +2,46 @@
   <%= t('history.index.page_title') %>
 <% end %>
 
-    <!-- 活動グラフ -->
-    <div class="card bg-base-100 border border-base-300 mb-3 sm:mb-4 lg:mb-6">
-      <div class="card-body p-4">
-        <div class="flex items-center justify-between mb-4">
-          <h3 class="text-2xl font-bold"><%= t('history.index.activity_graph') %></h3>
-          <%= form_with url: history_path, method: :get, local: true, class: "flex gap-2 items-center", id: "history-form" do %>
-            <%= select_tag :year,
-                options_for_select((2025..Date.current.year).to_a.reverse, @selected_year),
-                class: "select select-bordered select-sm w-20",
-                onchange: "this.form.submit();" %>
-            <label for="year" class="text-xs"><%= t('history.index.year') %></label>
+<div class="flex flex-col gap-3 sm:gap-4 lg:gap-6">
+  <!-- 活動グラフ -->
+  <%= render 'shared/card' do %>
+    <div class="flex items-center justify-between mb-4">
+      <h3 class="text-2xl font-bold"><%= t('history.index.activity_graph') %></h3>
+      <%= form_with url: history_path, method: :get, local: true, class: "flex gap-2 items-center", id: "history-form" do %>
+        <%= select_tag :year,
+            options_for_select((2025..Date.current.year).to_a.reverse, @selected_year),
+            class: "select select-bordered select-sm w-20",
+            onchange: "this.form.submit();" %>
+        <label for="year" class="text-xs"><%= t('history.index.year') %></label>
 
-            <%= select_tag :month,
-                options_for_select((1..12).to_a, @selected_month),
-                class: "select select-bordered select-sm w-16",
-                onchange: "this.form.submit();" %>
-            <label for="month" class="text-xs"><%= t('history.index.month') %></label>
-          <% end %>
-        </div>
-        <div class="overflow-x-auto">
-          <div id="sleep-chart"
-              data-series='<%= @series.to_json.html_safe %>'
-              class="min-w-[1200px] h-[250px] sm:h-[300px] lg:h-[350px]">
-          </div>
-        </div>
-
+        <%= select_tag :month,
+            options_for_select((1..12).to_a, @selected_month),
+            class: "select select-bordered select-sm w-16",
+            onchange: "this.form.submit();" %>
+        <label for="month" class="text-xs"><%= t('history.index.month') %></label>
+      <% end %>
+    </div>
+    <div class="overflow-x-auto">
+      <div id="sleep-chart"
+          data-series='<%= @series.to_json.html_safe %>'
+          class="min-w-[1200px] h-[250px] sm:h-[300px] lg:h-[350px]">
       </div>
     </div>
+  <% end %>
 
-    <!-- 記録テーブル -->
-    <div class="card bg-base-100 border border-base-300 mb-3 sm:mb-4 lg:mb-6">
-      <details class="group [&_summary::-webkit-details-marker]:hidden">
-        <summary class="cursor-pointer p-4 font-bold text-xl bg-base-100 flex justify-between items-center rounded-t-lg">
-          <%= t('history.index.this_month_records') %>
-          <span class="transition-transform duration-300 group-open:rotate-180">⤵︎</span>
-        </summary>
-        <div class="p-4">
-          <!-- モバイル用カード表示 -->
-          <div class="md:hidden space-y-2">
-            <% @monthly_records.each do |record| %>
-              <div class="card bg-base-100 border border-base-300 shadow-sm">
-                <details class="group">
-                  <summary class="cursor-pointer p-3 flex justify-between items-center list-none">
-                    <div class="flex-1">
-                      <div class="flex items-center gap-3 mb-1">
-                        <h4 class="font-bold text-sm">
-                          <%= record[:day].is_a?(Date) ? record[:day].strftime("%m-%d (%a)") : '--' %>
-                        </h4>
-                        <% if record[:id].present? %>
-                          <% if record[:day].is_a?(Date) && record[:day].to_date < Time.current.to_date %>
-                            <button onclick="event.stopPropagation(); openSleepRecordModal('edit', <%= record[:id] %>, '<%= record[:wake_times].present? ? Time.parse(record[:wake_times].first).strftime('%Y-%m-%dT%H:%M') : '' %>', '<%= record[:bed_times].present? ? Time.parse(record[:bed_times].last).strftime('%Y-%m-%dT%H:%M') : '' %>')" class="btn btn-xs btn-outline">編集</button>
-                          <% end %>
-                        <% else %>
-                          <% if record[:day].is_a?(Date) && record[:day].to_date < Time.current.to_date %>
-                            <button onclick="event.stopPropagation(); openSleepRecordModal('new', null, null, null, '<%= record[:day] %>')" class="btn btn-xs btn-outline btn-primary">追加</button>
-                          <% end %>
-                        <% end %>
-                      </div>
-                      <div class="text-xs text-base-content/70 flex gap-4">
-                        <span class="flex items-center gap-1">
-                          <i class="ph-fill ph-sun text-warning"></i>
-                          <% if record[:wake_times].present? %>
-                            <%= Time.parse(record[:wake_times].first).strftime("%H:%M") %>
-                          <% else %>
-                            -
-                          <% end %>
-                        </span>
-                        <span class="flex items-center gap-1">
-                          <i class="ph-fill ph-moon text-info"></i>
-                          <% if record[:bed_times].present? %>
-                            <%= Time.parse(record[:bed_times].last).strftime("%H:%M") %>
-                          <% else %>
-                            -
-                          <% end %>
-                        </span>
-                      </div>
-                    </div>
-                    <span class="transition-transform duration-300 group-open:rotate-180 text-base-content/50">▼</span>
-                  </summary>
+  <!-- 記録テーブル -->
+  <%= render 'shared/sleep_records_table',
+      records: @monthly_records,
+      title: t('history.index.this_month_records') %>
 
-                  <div class="px-3 pb-3 pt-2 border-t border-base-300">
-                    <div class="grid grid-cols-2 gap-3 text-sm">
-                      <div>
-                        <div class="text-xs text-base-content/70 mb-1"><%= t('history.index.wake_time') %></div>
-                        <% if record[:wake_times].present? %>
-                          <% record[:wake_times].each do |time| %>
-                            <span class="badge badge-success badge-sm mb-1 text-xs">
-                              <%= Time.parse(time).strftime("%H:%M") %>
-                            </span>
-                          <% end %>
-                        <% else %>
-                          <span class="text-base-content/40">-</span>
-                        <% end %>
-                      </div>
-
-                      <div>
-                        <div class="text-xs text-base-content/70 mb-1"><%= t('history.index.bed_time') %></div>
-                        <% if record[:bed_times].present? %>
-                          <% record[:bed_times].each do |time| %>
-                            <span class="badge badge-secondary badge-sm mb-1 text-xs">
-                              <%= Time.parse(time).strftime("%H:%M") %>
-                            </span>
-                          <% end %>
-                        <% else %>
-                          <span class="text-base-content/40">-</span>
-                        <% end %>
-                      </div>
-
-                      <div>
-                        <div class="text-xs text-base-content/70 mb-1"><%= t('history.index.cumulative_wake_hours') %></div>
-                        <div class="text-accent text-sm font-semibold">
-                          <%= record[:cumulative_wake_hours] || '-' %>
-                        </div>
-                      </div>
-
-                      <div>
-                        <div class="text-xs text-base-content/70 mb-1"><%= t('history.index.cumulative_sleep_hours') %></div>
-                        <div class="text-info text-sm font-semibold">
-                          <%= record[:cumulative_sleep_hours] || '-' %>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </details>
-              </div>
-            <% end %>
-          </div>
-
-          <!-- デスクトップ用テーブル表示 -->
-          <div class="hidden md:block overflow-x-auto">
-            <table class="table table-zebra w-full border-t border-base-300 text-sm">
-              <thead class="bg-base-200">
-                <tr>
-                  <th class="px-4 py-3 text-sm"><%= t('history.index.date') %></th>
-                  <th class="px-4 py-3 text-sm"><%= t('history.index.wake_time') %></th>
-                  <th class="px-4 py-3 text-sm"><%= t('history.index.bed_time') %></th>
-                  <th class="px-4 py-3 text-sm"><%= t('history.index.daily_wake_hours') %></th>
-                  <th class="px-4 py-3 text-sm"><%= t('history.index.daily_sleep_hours') %></th>
-                  <th class="px-4 py-3 text-sm"><%= t('history.index.cumulative_wake_hours') %></th>
-                  <th class="px-4 py-3 text-sm"><%= t('history.index.cumulative_sleep_hours') %></th>
-                  <th class="px-4 py-3 text-sm">操作</th>
-                </tr>
-              </thead>
-              <tbody>
-                <% @monthly_records.each do |record| %>
-                  <tr class="hover">
-                    <td class="px-4 py-3 whitespace-nowrap"><%= record[:day].is_a?(Date) ? record[:day].strftime("%m-%d (%a)") : '--' %></td>
-                    <td class="px-4 py-3">
-                      <% if record[:wake_times].present? %>
-                        <% record[:wake_times].each do |time| %>
-                          <span class="badge badge-success badge-sm mb-1 text-xs">
-                            <%= Time.parse(time).strftime("%m/%d_%H:%M") %>
-                          </span>
-                        <% end %>
-                      <% else %>
-                        <span class="text-base-content/40">-</span>
-                      <% end %>
-                    </td>
-                    <td class="px-4 py-3">
-                      <% if record[:bed_times].present? %>
-                        <% record[:bed_times].each do |time| %>
-                          <span class="badge badge-secondary badge-sm mb-1 text-xs">
-                            <%= Time.parse(time).strftime("%m/%d_%H:%M") %>
-                          </span>
-                        <% end %>
-                      <% else %>
-                        <span class="text-base-content/40">-</span>
-                      <% end %>
-                    </td>
-                    <td class="px-4 py-3 text-accent font-semibold">
-                      <%= record[:daily_wake_hours] ? sprintf("%.2f", record[:daily_wake_hours]) : '-' %>
-                    </td>
-                    <td class="px-4 py-3 text-info font-semibold">
-                      <%= record[:daily_sleep_hours] ? sprintf("%.2f", record[:daily_sleep_hours]) : '-' %>
-                    </td>
-                    <td class="px-4 py-3 text-accent text-sm font-semibold">
-                      <%= record[:cumulative_wake_hours] || '-' %>
-                    </td>
-                    <td class="px-4 py-3 text-info text-sm font-semibold">
-                      <%= record[:cumulative_sleep_hours] || '-' %>
-                    </td>
-                    <td class="px-4 py-3">
-                      <% if record[:id].present? %>
-                        <% if record[:day].is_a?(Date) && record[:day].to_date < Time.current.to_date %>
-                          <button onclick="openSleepRecordModal('edit', <%= record[:id] %>, '<%= record[:wake_times].present? ? Time.parse(record[:wake_times].first).strftime('%Y-%m-%dT%H:%M') : '' %>', '<%= record[:bed_times].present? ? Time.parse(record[:bed_times].last).strftime('%Y-%m-%dT%H:%M') : '' %>')" class="btn btn-xs btn-outline whitespace-nowrap">編集</button>
-                        <% end %>
-                      <% else %>
-                        <% if record[:day].is_a?(Date) && record[:day].to_date < Time.current.to_date %>
-                          <button onclick="openSleepRecordModal('new', null, null, null, '<%= record[:day] %>')" class="btn btn-xs btn-outline btn-primary whitespace-nowrap">追加</button>
-                        <% end %>
-                      <% end %>
-                    </td>
-                  </tr>
-                <% end %>
-              </tbody>
-            </table>
-          </div>
-        </div>
-      </details>
-    </div>
-
-    <!-- 月間統計 -->
-    <div class="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4 lg:gap-6">
-      <div class="card bg-base-100 border border-base-300 text-center p-3 sm:p-4">
-        <div class="text-[10px] sm:text-xs text-base-content/70 mb-1 sm:mb-2 leading-tight"><%= t('history.index.month_average_wake_hours') %></div>
-        <div class="text-lg sm:text-xl lg:text-2xl font-bold text-success">
-          <%= @month_average_wake_hours ? sprintf("%.2f", @month_average_wake_hours) : '-' %>h
-        </div>
-      </div>
-      <div class="card bg-base-100 border border-base-300 text-center p-3 sm:p-4">
-        <div class="text-[10px] sm:text-xs text-base-content/70 mb-1 sm:mb-2 leading-tight"><%= t('history.index.month_average_sleep_hours') %></div>
-        <div class="text-lg sm:text-xl lg:text-2xl font-bold text-info">
-          <%= @month_average_sleep_hours ? sprintf("%.2f", @month_average_sleep_hours) : '-' %>h
-        </div>
-      </div>
-      <div class="card bg-base-100 border border-base-300 text-center p-3 sm:p-4">
-        <div class="text-[10px] sm:text-xs text-base-content/70 mb-1 sm:mb-2 leading-tight"><%= t('history.index.month_average_wake_time') %></div>
-        <div class="text-lg sm:text-xl lg:text-2xl font-bold text-success">
-          <%= @month_average_wake_time || '-' %>
-        </div>
-      </div>
-      <div class="card bg-base-100 border border-base-300 text-center p-3 sm:p-4">
-        <div class="text-[10px] sm:text-xs text-base-content/70 mb-1 sm:mb-2 leading-tight"><%= t('history.index.month_average_bed_time') %></div>
-        <div class="text-lg sm:text-xl lg:text-2xl font-bold text-info">
-          <%= @month_average_bed_time || '-' %>
-        </div>
-      </div>
-    </div>
+  <!-- 月間統計 -->
+  <%= render 'shared/sleep_stats_cards',
+      average_wake_hours: @month_average_wake_hours,
+      average_sleep_hours: @month_average_sleep_hours,
+      average_wake_time: @month_average_wake_time,
+      average_bed_time: @month_average_bed_time,
+      average_wake_hours_label: t('history.index.month_average_wake_hours'),
+      average_sleep_hours_label: t('history.index.month_average_sleep_hours'),
+      average_wake_time_label: t('history.index.month_average_wake_time'),
+      average_bed_time_label: t('history.index.month_average_bed_time') %>
+</div>

--- a/app/views/shared/_card.html.erb
+++ b/app/views/shared/_card.html.erb
@@ -1,0 +1,8 @@
+<div class="card bg-base-100 border border-base-300 <%= local_assigns[:class] %>">
+  <div class="card-body p-4">
+    <% if local_assigns[:title].present? %>
+      <h3 class="card-title text-2xl font-bold"><%= title %></h3>
+    <% end %>
+    <%= yield %>
+  </div>
+</div>

--- a/app/views/shared/_event_details.html.erb
+++ b/app/views/shared/_event_details.html.erb
@@ -1,0 +1,38 @@
+<div class="space-y-3">
+  <%# 時刻情報 %>
+  <% if event.start.date_time %>
+    <%= render 'shared/event_info_row',
+        icon_type: 'clock',
+        content: capture do %>
+      <p class="text-sm">
+        <%= event.start.date_time.in_time_zone("Asia/Tokyo").strftime("%Y年%m月%d日 %H:%M") %>
+        <% if event.end.date_time %>
+          - <%= event.end.date_time.in_time_zone("Asia/Tokyo").strftime("%H:%M") %>
+        <% end %>
+      </p>
+    <% end %>
+  <% elsif event.start.date %>
+    <%= render 'shared/event_info_row', icon_type: 'calendar', content: '終日' %>
+  <% end %>
+
+  <%# 場所情報 %>
+  <% if event.location.present? %>
+    <%= render 'shared/event_info_row', icon_type: 'location', content: event.location %>
+  <% end %>
+
+  <%# 説明 %>
+  <% if event.description.present? %>
+    <%= render 'shared/event_info_row',
+        icon_type: 'description',
+        content: capture do %>
+      <p class="text-sm whitespace-pre-wrap"><%= event.description %></p>
+    <% end %>
+  <% end %>
+
+  <%# カレンダー名 %>
+  <% if event.respond_to?(:calendar_summary) && event.calendar_summary.present? %>
+    <div class="pt-2 border-t border-base-300">
+      <span class="badge badge-sm"><%= event.calendar_summary %></span>
+    </div>
+  <% end %>
+</div>

--- a/app/views/shared/_event_info_row.html.erb
+++ b/app/views/shared/_event_info_row.html.erb
@@ -1,0 +1,10 @@
+<div class="flex items-start gap-2">
+  <%= render 'shared/icon', type: icon_type, size: 5, color: 'base-content/70' %>
+  <% if content.is_a?(String) %>
+    <p class="<%= local_assigns[:text_class] || 'text-sm' %>"><%= content %></p>
+  <% else %>
+    <div class="<%= local_assigns[:text_class] || 'text-sm' %>">
+      <%= content %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/shared/_icon.html.erb
+++ b/app/views/shared/_icon.html.erb
@@ -1,0 +1,30 @@
+<%
+  size = local_assigns[:size] || 5
+  color = local_assigns[:color] || 'base-content/70'
+  flex_shrink = local_assigns.fetch(:flex_shrink, true)
+
+  icon_paths = {
+    'clock' => 'M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z',
+    'location' => 'M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z M15 11a3 3 0 11-6 0 3 3 0 016 0z',
+    'description' => 'M4 6h16M4 12h16M4 18h7',
+    'calendar' => 'M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z',
+    'plus' => 'M12 4v16m8-8H4',
+    'sun' => 'M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z',
+    'moon' => 'M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z'
+  }
+
+  path = icon_paths[type] || icon_paths['calendar']
+%>
+<svg xmlns="http://www.w3.org/2000/svg"
+     class="h-<%= size %> w-<%= size %> text-<%= color %> <%= 'flex-shrink-0' if flex_shrink %>"
+     fill="none"
+     viewBox="0 0 24 24"
+     stroke="currentColor">
+  <% if path.include?('M') && path.scan(/M/).count > 1 %>
+    <% path.split(/(?=M)/).each do |p| %>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="<%= p.strip %>" />
+    <% end %>
+  <% else %>
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="<%= path %>" />
+  <% end %>
+</svg>

--- a/app/views/shared/_sleep_records_table.html.erb
+++ b/app/views/shared/_sleep_records_table.html.erb
@@ -1,0 +1,172 @@
+<div class="card bg-base-100 border border-base-300 min-w-0">
+  <details class="group [&_summary::-webkit-details-marker]:hidden">
+    <summary class="cursor-pointer p-4 font-bold text-xl bg-base-100 flex justify-between items-center group-open:rounded-t-lg rounded-lg">
+      <%= title %>
+      <span class="transition-transform duration-300 group-open:rotate-180">⤵︎</span>
+    </summary>
+    <div class="p-4">
+      <!-- モバイル用カード表示 -->
+      <div class="md:hidden space-y-2">
+        <% records.each_with_index do |record, idx| %>
+          <div class="card bg-base-100 border border-base-300 shadow-sm">
+            <details class="group">
+              <summary class="cursor-pointer p-3 flex justify-between items-center list-none">
+                <div class="flex-1">
+                  <div class="flex items-center gap-3 mb-1">
+                    <h4 class="font-bold text-sm">
+                      <%= record[:day].is_a?(Date) ? record[:day].strftime("%m-%d (%a)") : '--' %>
+                    </h4>
+                    <% if record[:id].present? %>
+                      <% if record[:day].is_a?(Date) && record[:day].to_date < Time.current.to_date %>
+                        <button onclick="event.stopPropagation(); openSleepRecordModal('edit', <%= record[:id] %>, '<%= record[:wake_times].present? ? Time.parse(record[:wake_times].first).strftime('%Y-%m-%dT%H:%M') : '' %>', '<%= record[:bed_times].present? ? Time.parse(record[:bed_times].last).strftime('%Y-%m-%dT%H:%M') : '' %>')" class="btn btn-xs btn-outline">編集</button>
+                      <% end %>
+                    <% else %>
+                      <% if record[:day].is_a?(Date) && record[:day].to_date < Time.current.to_date %>
+                        <button onclick="event.stopPropagation(); openSleepRecordModal('new', null, null, null, '<%= record[:day] %>')" class="btn btn-xs btn-outline btn-primary">追加</button>
+                      <% end %>
+                    <% end %>
+                  </div>
+                  <div class="text-xs text-base-content/70 flex gap-4">
+                    <span class="flex items-center gap-1">
+                      <i class="ph-fill ph-sun text-warning"></i>
+                      <% if record[:wake_times].present? %>
+                        <%= Time.parse(record[:wake_times].first).strftime("%H:%M") %>
+                      <% else %>
+                        -
+                      <% end %>
+                    </span>
+                    <span class="flex items-center gap-1">
+                      <i class="ph-fill ph-moon text-info"></i>
+                      <% if record[:bed_times].present? %>
+                        <%= Time.parse(record[:bed_times].last).strftime("%H:%M") %>
+                      <% else %>
+                        -
+                      <% end %>
+                    </span>
+                  </div>
+                </div>
+                <span class="transition-transform duration-300 group-open:rotate-180 text-base-content/50">▼</span>
+              </summary>
+
+              <div class="px-3 pb-3 pt-2 border-t border-base-300">
+                <div class="grid grid-cols-2 gap-3 text-sm">
+                  <div>
+                    <div class="text-xs text-base-content/70 mb-1"><%= t('dashboard.index.wake_time') %></div>
+                    <% if record[:wake_times].present? %>
+                      <% record[:wake_times].each do |time| %>
+                        <span class="badge badge-success badge-sm mb-1 text-xs">
+                          <%= Time.parse(time).strftime("%H:%M") %>
+                        </span>
+                      <% end %>
+                    <% else %>
+                      <span class="text-base-content/40">-</span>
+                    <% end %>
+                  </div>
+
+                  <div>
+                    <div class="text-xs text-base-content/70 mb-1"><%= t('dashboard.index.bed_time') %></div>
+                    <% if record[:bed_times].present? %>
+                      <% record[:bed_times].each do |time| %>
+                        <span class="badge badge-secondary badge-sm mb-1 text-xs">
+                          <%= Time.parse(time).strftime("%H:%M") %>
+                        </span>
+                      <% end %>
+                    <% else %>
+                      <span class="text-base-content/40">-</span>
+                    <% end %>
+                  </div>
+
+                  <div>
+                    <div class="text-xs text-base-content/70 mb-1"><%= t('dashboard.index.cumulative_wake_hours') %></div>
+                    <div class="text-accent text-sm font-semibold">
+                      <%= record[:cumulative_wake_hours] || '-' %>
+                    </div>
+                  </div>
+
+                  <div>
+                    <div class="text-xs text-base-content/70 mb-1"><%= t('dashboard.index.cumulative_sleep_hours') %></div>
+                    <div class="text-info text-sm font-semibold">
+                      <%= record[:cumulative_sleep_hours] || '-' %>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </details>
+          </div>
+        <% end %>
+      </div>
+
+      <!-- デスクトップ用テーブル表示 -->
+      <div class="hidden md:block overflow-x-auto">
+        <table class="table table-zebra w-full border-t border-base-300 text-sm">
+          <thead class="bg-base-200">
+            <tr>
+              <th class="px-4 py-3 text-sm font-semibold text-base-content/70"><%= t('dashboard.index.date') %></th>
+              <th class="px-4 py-3 text-sm font-semibold text-base-content/70"><%= t('dashboard.index.wake_time') %></th>
+              <th class="px-4 py-3 text-sm font-semibold text-base-content/70"><%= t('dashboard.index.bed_time') %></th>
+              <th class="px-4 py-3 text-sm font-semibold text-base-content/70"><%= t('dashboard.index.daily_wake_hours') %></th>
+              <th class="px-4 py-3 text-sm font-semibold text-base-content/70"><%= t('dashboard.index.daily_sleep_hours') %></th>
+              <th class="px-4 py-3 text-sm font-semibold text-base-content/70"><%= t('dashboard.index.cumulative_wake_hours') %></th>
+              <th class="px-4 py-3 text-sm font-semibold text-base-content/70"><%= t('dashboard.index.cumulative_sleep_hours') %></th>
+              <th class="px-4 py-3 text-sm font-semibold text-base-content/70">操作</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% records.each_with_index do |record, idx| %>
+              <tr class="hover">
+                <td class="px-4 py-3 whitespace-nowrap">
+                  <%= record[:day].is_a?(Date) ? record[:day].strftime("%m-%d (%a)") : '--' %>
+                </td>
+                <td class="px-4 py-3">
+                  <% if record[:wake_times].present? %>
+                    <% record[:wake_times].each do |time| %>
+                      <span class="badge badge-success badge-sm mb-1 text-xs">
+                        <%= Time.parse(time).strftime("%m/%d_%H:%M") %>
+                      </span>
+                    <% end %>
+                  <% else %>
+                    <span class="text-base-content/40">-</span>
+                  <% end %>
+                </td>
+                <td class="px-4 py-3">
+                  <% if record[:bed_times].present? %>
+                    <% record[:bed_times].each do |time| %>
+                      <span class="badge badge-secondary badge-sm mb-1 text-xs">
+                        <%= Time.parse(time).strftime("%m/%d_%H:%M") %>
+                      </span>
+                    <% end %>
+                  <% else %>
+                    <span class="text-base-content/40">-</span>
+                  <% end %>
+                </td>
+                <td class="px-4 py-3 text-accent font-semibold">
+                  <%= record[:daily_wake_hours] ? sprintf("%.2f", record[:daily_wake_hours]) : '-' %>
+                </td>
+                <td class="px-4 py-3 text-info font-semibold">
+                  <%= record[:daily_sleep_hours] ? sprintf("%.2f", record[:daily_sleep_hours]) : '-' %>
+                </td>
+                <td class="px-4 py-3 text-accent text-sm font-semibold">
+                  <%= record[:cumulative_wake_hours] || '-' %>
+                </td>
+                <td class="px-4 py-3 text-info text-sm font-semibold">
+                  <%= record[:cumulative_sleep_hours] || '-' %>
+                </td>
+                <td class="px-4 py-3">
+                  <% if record[:id].present? %>
+                    <% if record[:day].is_a?(Date) && record[:day].to_date < Time.current.to_date %>
+                      <button onclick="openSleepRecordModal('edit', <%= record[:id] %>, '<%= record[:wake_times].present? ? Time.parse(record[:wake_times].first).strftime('%Y-%m-%dT%H:%M') : '' %>', '<%= record[:bed_times].present? ? Time.parse(record[:bed_times].last).strftime('%Y-%m-%dT%H:%M') : '' %>')" class="btn btn-xs btn-outline whitespace-nowrap">編集</button>
+                    <% end %>
+                  <% else %>
+                    <% if record[:day].is_a?(Date) && record[:day].to_date < Time.current.to_date %>
+                      <button onclick="openSleepRecordModal('new', null, null, null, '<%= record[:day] %>')" class="btn btn-xs btn-outline btn-primary whitespace-nowrap">追加</button>
+                    <% end %>
+                  <% end %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </details>
+</div>

--- a/app/views/shared/_sleep_stats_cards.html.erb
+++ b/app/views/shared/_sleep_stats_cards.html.erb
@@ -1,0 +1,26 @@
+<div class="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4 lg:gap-6">
+  <div class="card bg-base-100 border border-base-300 text-center p-3 sm:p-4">
+    <div class="text-[10px] sm:text-xs text-base-content/70 mb-1 sm:mb-2 leading-tight"><%= average_wake_hours_label %></div>
+    <div class="text-lg sm:text-xl lg:text-2xl font-bold text-success">
+      <%= average_wake_hours ? sprintf("%.2f", average_wake_hours) : '-' %>h
+    </div>
+  </div>
+  <div class="card bg-base-100 border border-base-300 text-center p-3 sm:p-4">
+    <div class="text-[10px] sm:text-xs text-base-content/70 mb-1 sm:mb-2 leading-tight"><%= average_sleep_hours_label %></div>
+    <div class="text-lg sm:text-xl lg:text-2xl font-bold text-info">
+      <%= average_sleep_hours ? sprintf("%.2f", average_sleep_hours) : '-' %>h
+    </div>
+  </div>
+  <div class="card bg-base-100 border border-base-300 text-center p-3 sm:p-4">
+    <div class="text-[10px] sm:text-xs text-base-content/70 mb-1 sm:mb-2 leading-tight"><%= average_wake_time_label %></div>
+    <div class="text-lg sm:text-xl lg:text-2xl font-bold text-primary">
+      <%= average_wake_time || "--:--" %>
+    </div>
+  </div>
+  <div class="card bg-base-100 border border-base-300 text-center p-3 sm:p-4">
+    <div class="text-[10px] sm:text-xs text-base-content/70 mb-1 sm:mb-2 leading-tight"><%= average_bed_time_label %></div>
+    <div class="text-lg sm:text-xl lg:text-2xl font-bold text-secondary">
+      <%= average_bed_time || "--:--" %>
+    </div>
+  </div>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -19,7 +19,7 @@
                 </svg>
                 <span><%= t('profiles.show.google_connected') %></span>
               </div>
-              <%= button_to disconnect_google_calendars_path, method: :delete, class: "btn btn-outline btn-error w-full", data: { confirm: t('profiles.show.google_disconnect_confirm') } do %>
+              <%= button_to google_calendar_connection_path, method: :delete, class: "btn btn-outline btn-error w-full", data: { confirm: t('profiles.show.google_disconnect_confirm') } do %>
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
                 </svg>


### PR DESCRIPTION
- 共通カードコンポーネント、アイコン、イベント詳細をpartial化
- 重複する睡眠記録テーブルと統計カードを共通化(~450行削減)
- Tailwindカスタムクラスを@layer componentsで定義
- モーダル操作用のJavaScriptヘルパー関数を追加
- チャート設定を定数化してロジックを整理
- 不要なencodingコメントを削除