### PR TITLE
feat: 気分トラッキング機能を追加

### DIFF
--- a/app/assets/javascripts/sleep_record_modal.js
+++ b/app/assets/javascripts/sleep_record_modal.js
@@ -1,3 +1,25 @@
+// ヘルパー関数: 要素の表示/非表示を切り替え
+window.toggleModalElement = function(element, show) {
+  if (!element) return;
+  if (show) {
+    element.classList.remove('hidden');
+  } else {
+    element.classList.add('hidden');
+  }
+};
+
+// ヘルパー関数: モーダルフッターのレイアウトを設定
+window.setModalFooterLayout = function(footer, hasDeleteButton) {
+  if (!footer) return;
+  if (hasDeleteButton) {
+    footer.classList.remove('justify-end');
+    footer.classList.add('justify-between');
+  } else {
+    footer.classList.remove('justify-between');
+    footer.classList.add('justify-end');
+  }
+};
+
 // 削除処理
 window.deleteSleepRecord = function() {
   if (!confirm('本当に削除しますか？')) {
@@ -29,7 +51,7 @@ function updateBedTimeHidden() {
   }
 }
 
-window.openSleepRecordModal = function(mode, recordId = null, wakeTime = null, bedTime = null, date = null) {
+window.openSleepRecordModal = function(mode, recordId = null, wakeTime = null, bedTime = null, date = null, mood = null) {
   const modal = document.getElementById('sleep_record_modal');
   const form = document.getElementById('sleep_record_form');
   const title = document.getElementById('sleep_record_modal_title');
@@ -79,6 +101,9 @@ window.openSleepRecordModal = function(mode, recordId = null, wakeTime = null, b
       document.getElementById('modal_bed_time_only').value = '22:00';
       updateBedTimeHidden();
     }
+
+    // メモフィールドをクリア
+    clearMemoFields();
   } else if (mode === 'edit') {
     title.textContent = modal.dataset.titleEdit;
     form.action = `/sleep_records/${recordId}`;
@@ -121,10 +146,72 @@ window.openSleepRecordModal = function(mode, recordId = null, wakeTime = null, b
       document.getElementById('modal_bed_time_only').value = '';
       document.getElementById('modal_bed_time').value = '';
     }
+
+    // メモフィールドを設定
+    setMemoFields(mood);
   }
 
   modal.showModal();
 };
+
+// スライダーの表示を更新（現在は不要だが、互換性のため残す）
+window.updateMoodDisplay = function(value) {
+  // 何もしない（表示は絵文字のみ）
+};
+
+// モーダルのスライダー値をenumキーに変換して絵文字も更新
+window.updateModalMoodDisplay = function(value) {
+  const moodKeys = {
+    1: 'very_bad',
+    2: 'bad',
+    3: 'neutral',
+    4: 'good',
+    5: 'very_good'
+  };
+  const moodEmojis = {
+    1: '😢',
+    2: '😕',
+    3: '😐',
+    4: '🙂',
+    5: '😊'
+  };
+
+  document.getElementById('modal_mood_hidden').value = moodKeys[value] || '';
+  const emojiElement = document.getElementById('modal_mood_emoji');
+  if (emojiElement) {
+    emojiElement.textContent = moodEmojis[value] || '😐';
+  }
+};
+
+// 気分フィールドをクリア
+function clearMemoFields() {
+  const moodRange = document.getElementById('modal_mood_range');
+  if (moodRange) {
+    moodRange.value = 3; // デフォルトは「普通」
+    updateModalMoodDisplay(3); // hidden fieldと絵文字も更新
+  }
+}
+
+// 気分フィールドを設定
+function setMemoFields(mood) {
+  const moodValues = {
+    'very_bad': 1,
+    'bad': 2,
+    'neutral': 3,
+    'good': 4,
+    'very_good': 5
+  };
+
+  const moodRange = document.getElementById('modal_mood_range');
+  if (moodRange) {
+    let moodValue = 3; // デフォルト
+    if (mood && mood !== '' && mood !== 'null' && moodValues[mood]) {
+      moodValue = moodValues[mood];
+    }
+    moodRange.value = moodValue;
+    updateModalMoodDisplay(moodValue); // hidden fieldと絵文字も更新
+  }
+}
 
 // フォーム送信時の処理
 function setupSleepRecordForm() {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -25,4 +25,15 @@ module ApplicationHelper
       }
     }
   end
+
+  def mood_icon(mood)
+    icons = {
+      "very_bad" => "😢",
+      "bad" => "😕",
+      "neutral" => "😐",
+      "good" => "🙂",
+      "very_good" => "😊"
+    }
+    content_tag(:span, icons[mood.to_s], class: "text-2xl", title: t("sleep_records.moods.#{mood}"))
+  end
 end

--- a/app/models/sleep_record.rb
+++ b/app/models/sleep_record.rb
@@ -1,7 +1,16 @@
 class SleepRecord < ApplicationRecord
   belongs_to :user
 
+  enum :mood, {
+    very_bad: 1,
+    bad: 2,
+    neutral: 3,
+    good: 4,
+    very_good: 5
+  }, prefix: true
+
   validates :wake_time, presence: true
+  validates :mood, inclusion: { in: moods.keys, allow_nil: true }
   validate :bed_time_after_wake_time
   validate :times_not_in_future
   validate :wake_time_after_previous_bed_time

--- a/app/services/sleep_record_aggregator.rb
+++ b/app/services/sleep_record_aggregator.rb
@@ -108,6 +108,7 @@ class SleepRecordAggregator
       day: first.wake_time.to_date,
       wake_times: [ format_time(first.wake_time) ],
       bed_times: last.bed_time ? [ format_time(last.bed_time) ] : [],
+      mood: first.mood,
       daily_sleep_hours: daily_sleep(first, all_records),
       daily_wake_hours: daily_wake(first, last),
       cumulative_sleep_hours: format_cumulative(cumulative_sleep),

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -19,19 +19,7 @@
 
         <!-- 記録カード（モバイル） -->
         <%= render 'shared/card', class: 'lg:hidden min-w-0' do %>
-          <div class="space-y-3">
-            <%= button_to I18n.t('dashboard.index.wake_record'), record_wake_sleep_records_path,
-                method: :post,
-                class: "btn btn-primary btn-lg w-full #{'btn-disabled' if @unwoken_record.present?}",
-                disabled: @unwoken_record.present?,
-                data: { test: 'mobile-wake-button' } %>
-            <%= button_to I18n.t('dashboard.index.bed_record'),
-                (@unwoken_record ? record_bed_sleep_record_path(@unwoken_record) : "#"),
-                method: :patch,
-                class: "btn btn-secondary btn-lg w-full #{'btn-disabled' if @unwoken_record.nil?}",
-                disabled: @unwoken_record.nil?,
-                data: { test: 'mobile-bed-button' } %>
-          </div>
+          <%= render 'shared/quick_record_form', unwoken_record: @unwoken_record, device: 'mobile' %>
         <% end %>
 
         <!-- 記録テーブル -->
@@ -57,19 +45,7 @@
 
         <!-- 記録カード -->
         <%= render 'shared/card' do %>
-          <div class="space-y-3">
-            <%= button_to I18n.t('dashboard.index.wake_record'), record_wake_sleep_records_path,
-                method: :post,
-                class: "btn btn-primary btn-lg w-full #{'btn-disabled' if @unwoken_record.present?}",
-                disabled: @unwoken_record.present?,
-                data: { test: 'desktop-wake-button' } %>
-            <%= button_to I18n.t('dashboard.index.bed_record'),
-                (@unwoken_record ? record_bed_sleep_record_path(@unwoken_record) : "#"),
-                method: :patch,
-                class: "btn btn-secondary btn-lg w-full #{'btn-disabled' if @unwoken_record.nil?}",
-                disabled: @unwoken_record.nil?,
-                data: { test: 'desktop-bed-button' } %>
-          </div>
+          <%= render 'shared/quick_record_form', unwoken_record: @unwoken_record, device: 'desktop' %>
         <% end %>
 
       </div>

--- a/app/views/shared/_quick_record_form.html.erb
+++ b/app/views/shared/_quick_record_form.html.erb
@@ -1,0 +1,86 @@
+<div class="space-y-4" id="quick-record-form-<%= device %>">
+  <!-- 起床・就寝ボタン -->
+  <div class="space-y-3">
+    <%= form_with url: record_wake_sleep_records_path, method: :post, local: true, id: "wake-form-#{device}" do |f| %>
+      <input type="hidden" name="sleep_record[mood]" id="<%= device %>_wake_mood_value">
+      <%= f.submit I18n.t('dashboard.index.wake_record'),
+          class: "btn btn-primary btn-lg w-full #{'btn-disabled' if unwoken_record.present?}",
+          disabled: unwoken_record.present?,
+          data: { test: "#{device}-wake-button" },
+          onclick: "copyMemoToWakeForm('#{device}')" %>
+    <% end %>
+
+    <% if unwoken_record %>
+      <%= form_with url: record_bed_sleep_record_path(unwoken_record), method: :patch, local: true, id: "bed-form-#{device}" do |f| %>
+        <input type="hidden" name="sleep_record[mood]" id="<%= device %>_bed_mood_value">
+        <%= f.submit I18n.t('dashboard.index.bed_record'),
+            class: "btn btn-secondary btn-lg w-full",
+            data: { test: "#{device}-bed-button" },
+            onclick: "copyMemoToBedForm('#{device}')" %>
+      <% end %>
+    <% else %>
+      <button type="button" class="btn btn-secondary btn-lg w-full btn-disabled" disabled data-test="<%= device %>-bed-button">
+        <%= I18n.t('dashboard.index.bed_record') %>
+      </button>
+    <% end %>
+  </div>
+
+  <!-- 気分 -->
+  <div class="divider text-sm"><%= t('sleep_records.form.mood_label') %></div>
+  <div class="form-control">
+    <div class="flex flex-col items-center gap-2">
+      <span class="text-6xl" id="<%= device %>_mood_emoji">😐</span>
+      <input type="range" min="1" max="5" value="3" step="1" id="<%= device %>_mood_range" class="range range-primary range-sm w-full" oninput="update<%= device.capitalize %>MoodDisplay(this.value)">
+    </div>
+    <input type="hidden" name="<%= device %>_mood" id="<%= device %>_mood_value" value="">
+    <div class="w-full flex justify-between px-1 mt-1 text-xs text-base-content/70">
+      <span>悪い</span>
+      <span>最高</span>
+    </div>
+  </div>
+</div>
+
+<script>
+// スライダー値をhidden fieldに設定して絵文字も更新
+window['update<%= device.capitalize %>MoodDisplay'] = function(value) {
+  const moodKeys = {
+    1: 'very_bad',
+    2: 'bad',
+    3: 'neutral',
+    4: 'good',
+    5: 'very_good'
+  };
+  const moodEmojis = {
+    1: '😢',
+    2: '😕',
+    3: '😐',
+    4: '🙂',
+    5: '😊'
+  };
+
+  document.getElementById('<%= device %>_mood_value').value = moodKeys[value] || '';
+  const emojiElement = document.getElementById('<%= device %>_mood_emoji');
+  if (emojiElement) {
+    emojiElement.textContent = moodEmojis[value] || '😐';
+  }
+};
+
+// 初期値を設定
+document.addEventListener('DOMContentLoaded', function() {
+  window['update<%= device.capitalize %>MoodDisplay'](3);
+});
+
+document.addEventListener('turbo:load', function() {
+  window['update<%= device.capitalize %>MoodDisplay'](3);
+});
+
+function copyMemoToWakeForm(device) {
+  const moodValue = document.getElementById(`${device}_mood_value`).value;
+  document.getElementById(`${device}_wake_mood_value`).value = moodValue || '';
+}
+
+function copyMemoToBedForm(device) {
+  const moodValue = document.getElementById(`${device}_mood_value`).value;
+  document.getElementById(`${device}_bed_mood_value`).value = moodValue || '';
+}
+</script>

--- a/app/views/shared/_sleep_record_modal.html.erb
+++ b/app/views/shared/_sleep_record_modal.html.erb
@@ -57,6 +57,21 @@
         <%= f.hidden_field :bed_time, id: "modal_bed_time" %>
       </div>
 
+      <!-- 気分 -->
+      <div class="divider"><%= t('sleep_records.form.mood_label') %></div>
+
+      <div class="form-control">
+        <div class="flex flex-col items-center gap-2">
+          <span class="text-7xl" id="modal_mood_emoji">😐</span>
+          <input type="range" min="1" max="5" value="3" step="1" id="modal_mood_range" class="range range-primary w-full" oninput="updateModalMoodDisplay(this.value)">
+        </div>
+        <%= f.hidden_field :mood, id: "modal_mood_hidden" %>
+        <div class="w-full flex justify-between px-1 mt-2 text-sm text-base-content/70">
+          <span>悪い</span>
+          <span>最高</span>
+        </div>
+      </div>
+
       <div class="flex justify-end gap-2 pt-4 border-t border-base-300" id="sleep_record_modal_footer">
         <!-- 削除ボタン（編集時のみ表示） -->
         <button type="button"

--- a/app/views/shared/_sleep_records_table.html.erb
+++ b/app/views/shared/_sleep_records_table.html.erb
@@ -18,7 +18,7 @@
                     </h4>
                     <% if record[:id].present? %>
                       <% if record[:day].is_a?(Date) && record[:day].to_date < Time.current.to_date %>
-                        <button onclick="event.stopPropagation(); openSleepRecordModal('edit', <%= record[:id] %>, '<%= record[:wake_times].present? ? Time.parse(record[:wake_times].first).strftime('%Y-%m-%dT%H:%M') : '' %>', '<%= record[:bed_times].present? ? Time.parse(record[:bed_times].last).strftime('%Y-%m-%dT%H:%M') : '' %>')" class="btn btn-xs btn-outline">編集</button>
+                        <button onclick="event.stopPropagation(); openSleepRecordModal('edit', <%= record[:id] %>, '<%= record[:wake_times].present? ? Time.parse(record[:wake_times].first).strftime('%Y-%m-%dT%H:%M') : '' %>', '<%= record[:bed_times].present? ? Time.parse(record[:bed_times].last).strftime('%Y-%m-%dT%H:%M') : '' %>', <%= record[:mood].present? ? "'#{record[:mood]}'" : 'null' %>)" class="btn btn-xs btn-outline">編集</button>
                       <% end %>
                     <% else %>
                       <% if record[:day].is_a?(Date) && record[:day].to_date < Time.current.to_date %>
@@ -77,6 +77,15 @@
                   </div>
 
                   <div>
+                    <div class="text-xs text-base-content/70 mb-1"><%= t('dashboard.index.mood') %></div>
+                    <% if record[:mood].present? %>
+                      <%= mood_icon(record[:mood]) %>
+                    <% else %>
+                      <span class="text-base-content/40">-</span>
+                    <% end %>
+                  </div>
+
+                  <div>
                     <div class="text-xs text-base-content/70 mb-1"><%= t('dashboard.index.cumulative_wake_hours') %></div>
                     <div class="text-accent text-sm font-semibold">
                       <%= record[:cumulative_wake_hours] || '-' %>
@@ -104,6 +113,7 @@
               <th class="px-4 py-3 text-sm font-semibold text-base-content/70"><%= t('dashboard.index.date') %></th>
               <th class="px-4 py-3 text-sm font-semibold text-base-content/70"><%= t('dashboard.index.wake_time') %></th>
               <th class="px-4 py-3 text-sm font-semibold text-base-content/70"><%= t('dashboard.index.bed_time') %></th>
+              <th class="px-4 py-3 text-sm font-semibold text-base-content/70"><%= t('dashboard.index.mood') %></th>
               <th class="px-4 py-3 text-sm font-semibold text-base-content/70"><%= t('dashboard.index.daily_wake_hours') %></th>
               <th class="px-4 py-3 text-sm font-semibold text-base-content/70"><%= t('dashboard.index.daily_sleep_hours') %></th>
               <th class="px-4 py-3 text-sm font-semibold text-base-content/70"><%= t('dashboard.index.cumulative_wake_hours') %></th>
@@ -139,6 +149,13 @@
                     <span class="text-base-content/40">-</span>
                   <% end %>
                 </td>
+                <td class="px-4 py-3 text-center">
+                  <% if record[:mood].present? %>
+                    <%= mood_icon(record[:mood]) %>
+                  <% else %>
+                    <span class="text-base-content/40">-</span>
+                  <% end %>
+                </td>
                 <td class="px-4 py-3 text-accent font-semibold">
                   <%= record[:daily_wake_hours] ? sprintf("%.2f", record[:daily_wake_hours]) : '-' %>
                 </td>
@@ -154,7 +171,7 @@
                 <td class="px-4 py-3">
                   <% if record[:id].present? %>
                     <% if record[:day].is_a?(Date) && record[:day].to_date < Time.current.to_date %>
-                      <button onclick="openSleepRecordModal('edit', <%= record[:id] %>, '<%= record[:wake_times].present? ? Time.parse(record[:wake_times].first).strftime('%Y-%m-%dT%H:%M') : '' %>', '<%= record[:bed_times].present? ? Time.parse(record[:bed_times].last).strftime('%Y-%m-%dT%H:%M') : '' %>')" class="btn btn-xs btn-outline whitespace-nowrap">編集</button>
+                      <button onclick="openSleepRecordModal('edit', <%= record[:id] %>, '<%= record[:wake_times].present? ? Time.parse(record[:wake_times].first).strftime('%Y-%m-%dT%H:%M') : '' %>', '<%= record[:bed_times].present? ? Time.parse(record[:bed_times].last).strftime('%Y-%m-%dT%H:%M') : '' %>', <%= record[:mood].present? ? "'#{record[:mood]}'" : 'null' %>)" class="btn btn-xs btn-outline whitespace-nowrap">編集</button>
                     <% end %>
                   <% else %>
                     <% if record[:day].is_a?(Date) && record[:day].to_date < Time.current.to_date %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -18,6 +18,7 @@ ja:
       cumulative_sleep_hours: "週累計睡眠（h）"
       wake_record: "起床記録"
       bed_record: "就寝記録"
+      mood: "気分"
   history:
     index:
       page_title: "履歴"
@@ -37,6 +38,7 @@ ja:
       daily_sleep_hours: "睡眠時間（h）"
       cumulative_wake_hours: "月累計活動（h）"
       cumulative_sleep_hours: "月累計睡眠（h）"
+      mood: "気分"
   profiles:
     show:
       page_title: "プロフィール"
@@ -83,6 +85,14 @@ ja:
     terms: "利用規約"
     privacy: "プライバシーポリシー"
   sleep_records:
+    form:
+      mood_label: "気分"
+    moods:
+      very_bad: "とても悪い"
+      bad: "悪い"
+      neutral: "普通"
+      good: "良い"
+      very_good: "とても良い"
     new:
       page_title: "睡眠記録を追加"
       wake_time_label: "起床時刻"

--- a/db/migrate/20260111152712_add_memo_fields_to_sleep_records.rb
+++ b/db/migrate/20260111152712_add_memo_fields_to_sleep_records.rb
@@ -1,0 +1,7 @@
+class AddMemoFieldsToSleepRecords < ActiveRecord::Migration[7.2]
+  def change
+    add_column :sleep_records, :mood, :integer
+    add_column :sleep_records, :condition, :integer
+    add_column :sleep_records, :notes, :text
+  end
+end

--- a/db/migrate/20260113071813_remove_unused_memo_fields_from_sleep_records.rb
+++ b/db/migrate/20260113071813_remove_unused_memo_fields_from_sleep_records.rb
@@ -1,0 +1,6 @@
+class RemoveUnusedMemoFieldsFromSleepRecords < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :sleep_records, :condition, :integer
+    remove_column :sleep_records, :notes, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_11_08_050719) do
+ActiveRecord::Schema[7.2].define(version: 2026_01_13_071813) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -21,6 +21,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_11_08_050719) do
     t.text "note"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "mood"
     t.index ["user_id"], name: "index_sleep_records_on_user_id"
   end
 

--- a/spec/system/dashboard_spec.rb
+++ b/spec/system/dashboard_spec.rb
@@ -15,14 +15,14 @@ RSpec.describe "Dashboard", type: :system do
 
   it "起床→就寝の記録フローが正常に動作すること" do
     # 起床記録
-    find('button[data-test="mobile-wake-button"], button[data-test="desktop-wake-button"]', match: :first).click
-    expect(page).to have_content(I18n.t('dashboard.index.wake_record'))
+    click_button I18n.t('dashboard.index.wake_record'), match: :first
+    expect(page).to have_content(I18n.t('sleep_records.create.wake_time_recorded'))
 
     # 就寝記録ボタンが有効になる
     expect(page).to have_button(I18n.t('dashboard.index.bed_record'), disabled: false)
 
     # 就寝記録
-    find('button[data-test="mobile-bed-button"], button[data-test="desktop-bed-button"]', match: :first).click
-    expect(page).to have_content(I18n.t('dashboard.index.bed_record'))
+    click_button I18n.t('dashboard.index.bed_record'), match: :first
+    expect(page).to have_content(I18n.t('sleep_records.update.bed_time_recorded'))
   end
 end


### PR DESCRIPTION
睡眠記録に気分（mood）を記録できる機能を追加。
5段階（😢 とても悪い 〜 😊 とても良い）のスライダーUIで記録。

## 主な変更

### データベース
- sleep_recordsテーブルにmoodカラム（integer型）を追加
- condition/notesカラムは不要のため削除

### モデル
- SleepRecordモデルにmood enumを定義（1-5の整数値）
- moodのバリデーションを追加（オプション項目）

### ビュー
- クイック記録フォームに気分スライダーを追加（text-6xl絵文字）
- 睡眠記録モーダルに気分スライダーを追加（text-7xl絵文字）
- 週間記録テーブルに気分列を追加（絵文字表示）
- スライダー上部に動的に変化する絵文字を表示
- ラベルは「悪い」〜「最高」

### JavaScript
- スライダー値変更時に絵文字とhidden fieldを自動更新
- 起床/就寝記録時に気分を自動コピー

### 国際化
- 日本語翻訳を追加（mood_label、moods.*）

## 技術詳細
- DaisyUI range input + Tailwind CSS
- Turbo対応（DOMContentLoaded/turbo:loadで初期化）
- モバイル/デスクトップ両対応